### PR TITLE
feat(core): add built-in cloud shape

### DIFF
--- a/packages/core/src/geometry.js
+++ b/packages/core/src/geometry.js
@@ -193,83 +193,46 @@ export const ellipsePolygon = (w, h, n = 32) => {
   return pts
 }
 
+// The cloud outline, as cubic Bézier segments in unit space (fractions of
+// w/h). One source of truth: cloudPolygon() samples these for hit-testing and
+// for the wobbled 'draw' path, while shapes.js strokes them directly for the
+// crisp dash styles — move the curve here and both follow.
+export const CLOUD_START = [0.15, 0.62]
+export const CLOUD_CURVES = [
+  // [c1x, c1y, c2x, c2y, endX, endY] — each picks up where the last ended
+  [0.02, 0.60, 0.02, 0.38, 0.16, 0.35],
+  [0.16, 0.15, 0.36, 0.10, 0.46, 0.20],
+  [0.54, 0.10, 0.74, 0.10, 0.82, 0.32],
+  [0.98, 0.32, 0.98, 0.58, 0.84, 0.60],
+  [0.82, 0.74, 0.66, 0.80, 0.55, 0.75],
+  [0.44, 0.70, 0.28, 0.78, 0.24, 0.68],
+  [0.22, 0.65, 0.18, 0.62, 0.15, 0.62],
+]
+
 // cloud sampled as a polygon (hit-testing / selection)
 export const cloudPolygon = (w, h, steps = 12) => {
-  const pts = []
-
-  // cubic Bézier sampler
-  const bezier = (p0, p1, p2, p3) => {
-    for (let i = 0; i <= steps; i++) {
+  let px = CLOUD_START[0] * w
+  let py = CLOUD_START[1] * h
+  const pts = [px, py]
+  for (const [c1x, c1y, c2x, c2y, ex, ey] of CLOUD_CURVES) {
+    const x1 = c1x * w, y1 = c1y * h
+    const x2 = c2x * w, y2 = c2y * h
+    const x3 = ex * w, y3 = ey * h
+    // start at i=1: t=0 is the previous segment's end, already in the list
+    for (let i = 1; i <= steps; i++) {
       const t = i / steps
       const mt = 1 - t
-
-      const x =
-        mt * mt * mt * p0.x +
-        3 * mt * mt * t * p1.x +
-        3 * mt * t * t * p2.x +
-        t * t * t * p3.x
-
-      const y =
-        mt * mt * mt * p0.y +
-        3 * mt * mt * t * p1.y +
-        3 * mt * t * t * p2.y +
-        t * t * t * p3.y
-
-      pts.push(x, y)
+      pts.push(
+        mt * mt * mt * px + 3 * mt * mt * t * x1 + 3 * mt * t * t * x2 + t * t * t * x3,
+        mt * mt * mt * py + 3 * mt * mt * t * y1 + 3 * mt * t * t * y2 + t * t * t * y3,
+      )
     }
+    px = x3
+    py = y3
   }
-
-  const p0 = { x: w * 0.15, y: h * 0.62 }
-
-  bezier(
-    p0,
-    { x: w * 0.02, y: h * 0.60 },
-    { x: w * 0.02, y: h * 0.38 },
-    { x: w * 0.16, y: h * 0.35 }
-  )
-
-  bezier(
-    { x: w * 0.16, y: h * 0.35 },
-    { x: w * 0.16, y: h * 0.15 },
-    { x: w * 0.36, y: h * 0.10 },
-    { x: w * 0.46, y: h * 0.20 }
-  )
-
-  bezier(
-    { x: w * 0.46, y: h * 0.20 },
-    { x: w * 0.54, y: h * 0.10 },
-    { x: w * 0.74, y: h * 0.10 },
-    { x: w * 0.82, y: h * 0.32 }
-  )
-
-  bezier(
-    { x: w * 0.82, y: h * 0.32 },
-    { x: w * 0.98, y: h * 0.32 },
-    { x: w * 0.98, y: h * 0.58 },
-    { x: w * 0.84, y: h * 0.60 }
-  )
-
-  bezier(
-    { x: w * 0.84, y: h * 0.60 },
-    { x: w * 0.82, y: h * 0.74 },
-    { x: w * 0.66, y: h * 0.80 },
-    { x: w * 0.55, y: h * 0.75 }
-  )
-
-  bezier(
-    { x: w * 0.55, y: h * 0.75 },
-    { x: w * 0.44, y: h * 0.70 },
-    { x: w * 0.28, y: h * 0.78 },
-    { x: w * 0.24, y: h * 0.68 }
-  )
-
-  bezier(
-    { x: w * 0.24, y: h * 0.68 },
-    { x: w * 0.22, y: h * 0.65 },
-    { x: w * 0.18, y: h * 0.62 },
-    p0
-  )
-
+  // the last curve lands back on the start point — drop it so the closed
+  // polygon has no zero-length edge
+  pts.length -= 2
   return pts
 }
 

--- a/packages/core/src/geometry.js
+++ b/packages/core/src/geometry.js
@@ -175,6 +175,8 @@ export const geoPolygon = (geo, w, h) => {
       }
       return pts
     }
+    case 'cloud':
+      return cloudPolygon(w, h)
     case 'rectangle':
     default:
       return [0, 0, w, 0, w, h, 0, h]
@@ -188,6 +190,86 @@ export const ellipsePolygon = (w, h, n = 32) => {
     const a = (i / n) * Math.PI * 2
     pts.push(w / 2 + (Math.cos(a) * w) / 2, h / 2 + (Math.sin(a) * h) / 2)
   }
+  return pts
+}
+
+// cloud sampled as a polygon (hit-testing / selection)
+export const cloudPolygon = (w, h, steps = 12) => {
+  const pts = []
+
+  // cubic Bézier sampler
+  const bezier = (p0, p1, p2, p3) => {
+    for (let i = 0; i <= steps; i++) {
+      const t = i / steps
+      const mt = 1 - t
+
+      const x =
+        mt * mt * mt * p0.x +
+        3 * mt * mt * t * p1.x +
+        3 * mt * t * t * p2.x +
+        t * t * t * p3.x
+
+      const y =
+        mt * mt * mt * p0.y +
+        3 * mt * mt * t * p1.y +
+        3 * mt * t * t * p2.y +
+        t * t * t * p3.y
+
+      pts.push(x, y)
+    }
+  }
+
+  const p0 = { x: w * 0.15, y: h * 0.62 }
+
+  bezier(
+    p0,
+    { x: w * 0.02, y: h * 0.60 },
+    { x: w * 0.02, y: h * 0.38 },
+    { x: w * 0.16, y: h * 0.35 }
+  )
+
+  bezier(
+    { x: w * 0.16, y: h * 0.35 },
+    { x: w * 0.16, y: h * 0.15 },
+    { x: w * 0.36, y: h * 0.10 },
+    { x: w * 0.46, y: h * 0.20 }
+  )
+
+  bezier(
+    { x: w * 0.46, y: h * 0.20 },
+    { x: w * 0.54, y: h * 0.10 },
+    { x: w * 0.74, y: h * 0.10 },
+    { x: w * 0.82, y: h * 0.32 }
+  )
+
+  bezier(
+    { x: w * 0.82, y: h * 0.32 },
+    { x: w * 0.98, y: h * 0.32 },
+    { x: w * 0.98, y: h * 0.58 },
+    { x: w * 0.84, y: h * 0.60 }
+  )
+
+  bezier(
+    { x: w * 0.84, y: h * 0.60 },
+    { x: w * 0.82, y: h * 0.74 },
+    { x: w * 0.66, y: h * 0.80 },
+    { x: w * 0.55, y: h * 0.75 }
+  )
+
+  bezier(
+    { x: w * 0.55, y: h * 0.75 },
+    { x: w * 0.44, y: h * 0.70 },
+    { x: w * 0.28, y: h * 0.78 },
+    { x: w * 0.24, y: h * 0.68 }
+  )
+
+  bezier(
+    { x: w * 0.24, y: h * 0.68 },
+    { x: w * 0.22, y: h * 0.65 },
+    { x: w * 0.18, y: h * 0.62 },
+    p0
+  )
+
   return pts
 }
 

--- a/packages/core/src/palette.js
+++ b/packages/core/src/palette.js
@@ -109,7 +109,7 @@ export const FONTS = {
   mono: "'SF Mono', ui-monospace, Menlo, monospace",
 }
 
-export const GEO_IDS = ['rectangle', 'ellipse', 'triangle', 'diamond', 'hexagon', 'star']
+export const GEO_IDS = ['rectangle', 'ellipse', 'triangle', 'diamond', 'hexagon', 'star', 'cloud']
 
 // Highlighter: wide translucent band that multiplies into the paper.
 export const HIGHLIGHT_ALPHA = 0.55

--- a/packages/core/src/shapes.js
+++ b/packages/core/src/shapes.js
@@ -9,7 +9,8 @@ import {
 } from './palette.js'
 import {
   ptsBounds, rotWith, distToPolyline, pointInPolygon, pointInEllipse,
-  geoPolygon, ellipsePolygon, wobblePolyline, traceSmooth, segIntersectsBounds,
+  geoPolygon, ellipsePolygon, cloudPolygon, CLOUD_START, CLOUD_CURVES,
+  wobblePolyline, traceSmooth, segIntersectsBounds,
   boundsIntersect, boundsContain,
 } from './geometry.js'
 import { strokeOutline } from './freehand.js'
@@ -233,50 +234,20 @@ function geoPath(shape) {
       path.ellipse(p.w / 2, p.h / 2, Math.max(0.5, p.w / 2), Math.max(0.5, p.h / 2), 0, 0, Math.PI * 2)
     }
   } else if (p.geo === 'cloud') {
-
-    const w = p.w
-    const h = p.h
-
-    path.moveTo(w * 0.15, h * 0.62)
-
-    path.bezierCurveTo(
-      w * 0.02, h * 0.60,
-      w * 0.02, h * 0.38,
-      w * 0.16, h * 0.35
-    )
-    path.bezierCurveTo(
-      w * 0.16, h * 0.15,
-      w * 0.36, h * 0.10,
-      w * 0.46, h * 0.20
-    )
-    path.bezierCurveTo(
-      w * 0.54, h * 0.10,
-      w * 0.74, h * 0.10,
-      w * 0.82, h * 0.32
-    )
-    path.bezierCurveTo(
-      w * 0.98, h * 0.32,
-      w * 0.98, h * 0.58,
-      w * 0.84, h * 0.60
-    )
-    path.bezierCurveTo(
-      w * 0.82, h * 0.74,
-      w * 0.66, h * 0.80,
-      w * 0.55, h * 0.75
-    )
-    path.bezierCurveTo(
-      w * 0.44, h * 0.70,
-      w * 0.28, h * 0.78,
-      w * 0.24, h * 0.68
-    )
-    path.bezierCurveTo(
-      w * 0.22, h * 0.65,
-      w * 0.18, h * 0.62,
-      w * 0.15, h * 0.62
-    )
-
-    path.closePath()
-
+    if (p.dash === 'draw') {
+      // same treatment as the ellipse: sample the curve, wobble it, retrace
+      // smoothly — so the cloud is hand-drawn like every other shape in the
+      // default style rather than a lone crisp vector
+      const pts = wobblePolyline(cloudPolygon(p.w, p.h), shape.id, { step: 18, amp: Math.min(2, (p.w + p.h) / 160 + 0.6) })
+      traceSmooth(path, pts, true)
+      path.closePath()
+    } else {
+      path.moveTo(CLOUD_START[0] * p.w, CLOUD_START[1] * p.h)
+      for (const [c1x, c1y, c2x, c2y, ex, ey] of CLOUD_CURVES) {
+        path.bezierCurveTo(c1x * p.w, c1y * p.h, c2x * p.w, c2y * p.h, ex * p.w, ey * p.h)
+      }
+      path.closePath()
+    }
   } else {
     const poly = geoPolygon(p.geo, p.w, p.h)
     if (p.dash === 'draw') {

--- a/packages/core/src/shapes.js
+++ b/packages/core/src/shapes.js
@@ -232,6 +232,51 @@ function geoPath(shape) {
     } else {
       path.ellipse(p.w / 2, p.h / 2, Math.max(0.5, p.w / 2), Math.max(0.5, p.h / 2), 0, 0, Math.PI * 2)
     }
+  } else if (p.geo === 'cloud') {
+
+    const w = p.w
+    const h = p.h
+
+    path.moveTo(w * 0.15, h * 0.62)
+
+    path.bezierCurveTo(
+      w * 0.02, h * 0.60,
+      w * 0.02, h * 0.38,
+      w * 0.16, h * 0.35
+    )
+    path.bezierCurveTo(
+      w * 0.16, h * 0.15,
+      w * 0.36, h * 0.10,
+      w * 0.46, h * 0.20
+    )
+    path.bezierCurveTo(
+      w * 0.54, h * 0.10,
+      w * 0.74, h * 0.10,
+      w * 0.82, h * 0.32
+    )
+    path.bezierCurveTo(
+      w * 0.98, h * 0.32,
+      w * 0.98, h * 0.58,
+      w * 0.84, h * 0.60
+    )
+    path.bezierCurveTo(
+      w * 0.82, h * 0.74,
+      w * 0.66, h * 0.80,
+      w * 0.55, h * 0.75
+    )
+    path.bezierCurveTo(
+      w * 0.44, h * 0.70,
+      w * 0.28, h * 0.78,
+      w * 0.24, h * 0.68
+    )
+    path.bezierCurveTo(
+      w * 0.22, h * 0.65,
+      w * 0.18, h * 0.62,
+      w * 0.15, h * 0.62
+    )
+
+    path.closePath()
+
   } else {
     const poly = geoPolygon(p.geo, p.w, p.h)
     if (p.dash === 'draw') {

--- a/packages/core/src/ui.js
+++ b/packages/core/src/ui.js
@@ -37,6 +37,7 @@ const ICONS = {
   diamond: SVG('<path d="M2.7 10.3a2.41 2.41 0 0 0 0 3.41l7.59 7.59a2.41 2.41 0 0 0 3.41 0l7.59-7.59a2.41 2.41 0 0 0 0-3.41l-7.59-7.59a2.41 2.41 0 0 0-3.41 0Z"/>'),
   hexagon: SVG('<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>'),
   star: SVG('<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>'),
+  cloud: SVG(`<path d="M7 17h10a4 4 0 0 0 .5-8A5.5 5.5 0 0 0 7 10a3.5 3.5 0 0 0 0 7z"/>`),
   // menu glyphs
   download: SVG('<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/><path d="M12 15V3"/>'),
   transparent: SVG('<rect width="18" height="18" x="3" y="3" rx="2"/><rect x="4" y="4" width="8" height="8" fill="currentColor" fill-opacity=".22" stroke="none"/><rect x="12" y="12" width="8" height="8" fill="currentColor" fill-opacity=".22" stroke="none"/>'),

--- a/packages/core/test/geometry.test.js
+++ b/packages/core/test/geometry.test.js
@@ -3,7 +3,7 @@ import {
   clamp, lerp, boundsUnion, boundsExpand, boundsContain, boundsIntersect,
   ptsBounds, rotWith, distToSegSq, distToPolyline, pointInPolygon,
   pointInEllipse, segIntersectsBounds, seededRand, wobblePolyline,
-  geoPolygon, ellipsePolygon,
+  geoPolygon, ellipsePolygon, cloudPolygon,
 } from '../src/geometry.js'
 
 describe('scalars', () => {
@@ -115,8 +115,24 @@ describe('geo polygon builders', () => {
     expect(geoPolygon('unknown', 10, 10).length).toBe(8) // falls back to rect
   })
 
+  it('cloudPolygon closes without a repeated point and scales with the box', () => {
+    const pts = cloudPolygon(100, 80)
+    expect(pts.length).toBeGreaterThan(40)
+    expect(pts.length % 2).toBe(0)
+    // the final curve lands back on the start, so it must not be emitted twice
+    const n = pts.length
+    expect(pts[n - 2] === pts[0] && pts[n - 1] === pts[1]).toBe(false)
+    // every sample scales linearly with the box
+    const big = cloudPolygon(200, 160)
+    for (let i = 0; i < pts.length; i++) expect(big[i]).toBeCloseTo(pts[i] * 2, 6)
+  })
+
+  it('geoPolygon routes cloud through cloudPolygon', () => {
+    expect(geoPolygon('cloud', 60, 40)).toEqual(cloudPolygon(60, 40))
+  })
+
   it('polygons stay inside their box', () => {
-    for (const kind of ['rectangle', 'triangle', 'diamond', 'hexagon', 'star']) {
+    for (const kind of ['rectangle', 'triangle', 'diamond', 'hexagon', 'star', 'cloud']) {
       const pts = geoPolygon(kind, 40, 30)
       for (let i = 0; i < pts.length; i += 2) {
         expect(pts[i]).toBeGreaterThanOrEqual(0)


### PR DESCRIPTION
## What & why

This PR adds a new built-in cloud shape to QuickDraw, including rendering, hit-testing, and a toolbar icon.

### Changes

- Added cloud geometry
- Added cloud toolbar icon
- Added rendering with Bézier curves
- Added hit-testing support
- Supports selection, resize, fill, stroke, and erase

## Checklist

- [x] Tested locally
- [x] No new runtime dependencies

Closes #2