### PR TITLE
Update package-lock.json for the 0.2.0 workspace bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "name": "quickdraw-app",
       "version": "0.0.0",
       "dependencies": {
-        "@quickdrawjs/core": "^0.1.3"
+        "@quickdrawjs/core": "^0.2.0"
       },
       "devDependencies": {
         "vite": "^6.3.0"
@@ -137,7 +137,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.3.0",
-        "@quickdrawjs/core": "^0.1.3",
+        "@quickdrawjs/core": "^0.2.0",
         "astro": "^5.7.0"
       }
     },
@@ -145,7 +145,7 @@
       "name": "quickdraw-react-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@quickdrawjs/react": "^0.1.3",
+        "@quickdrawjs/react": "^0.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -14629,15 +14629,15 @@
     },
     "packages/core": {
       "name": "@quickdrawjs/core",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT"
     },
     "packages/react": {
       "name": "@quickdrawjs/react",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@quickdrawjs/core": "0.1.3"
+        "@quickdrawjs/core": "0.2.0"
       },
       "peerDependencies": {
         "react": ">=17"
@@ -14645,10 +14645,10 @@
     },
     "packages/react-native": {
       "name": "@quickdrawjs/react-native",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@quickdrawjs/core": "0.1.3"
+        "@quickdrawjs/core": "0.2.0"
       },
       "devDependencies": {
         "esbuild": "^0.25.0"


### PR DESCRIPTION
The 0.2.0 release bumped every package.json but not the lockfile, so a fresh install (Vercel) could not resolve @quickdrawjs/core@^0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)