### PR TITLE
Serve the docs static export under /docs on Vercel

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/docs", "destination": "/" },
+    { "source": "/docs/", "destination": "/" },
+    { "source": "/docs/:path(.+)", "destination": "/:path" }
+  ]
+}


### PR DESCRIPTION
The git-connected build serves the static export at the root while basePath links point at /docs/... — rewrite the /docs prefix onto the exported files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)