### PR TITLE
Fix docs asset 404s: rewrite pattern did not span slashes

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -3,6 +3,6 @@
   "rewrites": [
     { "source": "/docs", "destination": "/" },
     { "source": "/docs/", "destination": "/" },
-    { "source": "/docs/:path(.+)", "destination": "/:path" }
+    { "source": "/docs/:path(.*)", "destination": "/:path" }
   ]
 }


### PR DESCRIPTION
Multi-segment paths like /docs/_next/static/css/x.css fell through the /docs rewrite, so docs pages rendered unstyled. Use (.*) as the website proxy does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)