### PR TITLE
Serve docs as pure static files under /docs

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "rewrites": [
-    { "source": "/docs", "destination": "/" },
-    { "source": "/docs/", "destination": "/" },
-    { "source": "/docs/:path(.*)", "destination": "/:path" }
-  ]
+  "framework": null,
+  "buildCommand": "npm run build && rm -rf .static && mkdir -p .static/docs && cp -R out/. .static/docs/",
+  "outputDirectory": ".static",
+  "trailingSlash": true,
+  "redirects": [{ "source": "/", "destination": "/docs/", "permanent": false }]
 }


### PR DESCRIPTION
Vercel's Next framework layer intercepts /docs/_next/* before user rewrites, so assets 404'd and pages rendered unstyled. Copy the static export into .static/docs and serve it without framework routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)