### PR TITLE
Blue default ink, theme-following canvas chrome, sponsors, and a showcase

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Shows the "Sponsor" button on the repo page.
+github: nmndwivedi
+custom: ['https://tryquickdraw.com/sponsors/']

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # Shows the "Sponsor" button on the repo page.
-github: nmndwivedi
+github: quickdrawjs
 custom: ['https://tryquickdraw.com/sponsors/']

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Question or idea
-    url: https://github.com/nmndwivedi/quickdraw/discussions
+    url: https://github.com/quickdrawjs/quickdraw/discussions
     about: Not a bug or a concrete feature request? Start a discussion.
   - name: Security issue
-    url: https://github.com/nmndwivedi/quickdraw/security/advisories/new
+    url: https://github.com/quickdrawjs/quickdraw/security/advisories/new
     about: Please report vulnerabilities privately, not as public issues.

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -1,0 +1,55 @@
+name: Sponsors
+
+# Keeps docs/sponsors.json current so the website's sponsor wall features
+# sponsors automatically — new sponsors appear within a day of sponsoring,
+# lapsed ones roll off, no manual list edits.
+#
+# The Sponsors GraphQL API rejects anonymous reads, so this runs here with a
+# token. If the default Actions token can't read the org's sponsorships, add
+# a classic PAT with read:org as the SPONSORS_TOKEN secret — it's preferred
+# automatically when set.
+
+on:
+  schedule:
+    - cron: '43 4 * * *' # daily, 04:43 UTC
+  workflow_dispatch: # refresh on demand
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/sponsors.mjs'
+      - '.github/workflows/sponsors.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sponsors
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Refresh sponsors snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.SPONSORS_TOKEN || secrets.GITHUB_TOKEN }}
+        run: node scripts/sponsors.mjs
+
+      - name: Commit if the wall changed
+        run: |
+          # Stage first: on the very first run the file is untracked, and
+          # `git diff` alone would report no change and skip the seed commit.
+          git add -A docs/sponsors.json
+          if git diff --cached --quiet; then
+            echo "No change."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: update sponsors [skip ci]"
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,18 @@ fastest way to poke the raw engine.
 - Hand-written type declarations live in each package's `types/index.d.ts`;
   update them together with API changes.
 - Keep comments in the existing voice: explain *why*, not *what*.
+
+## Add your project to the showcase
+
+Built something with Quickdraw? Add it to the
+["Made with Quickdraw" table in the README](README.md#made-with-quickdraw) —
+it's the standard drill:
+
+1. Edit `README.md` and add one row to the table, keeping it alphabetical.
+2. Link the project name to a live URL (or the repo if it isn't public yet),
+   and keep the description to 15 words or fewer, no superlatives.
+3. Open a PR titled `showcase: <project name>`. Nothing else in the diff.
+
+Any real project that ships Quickdraw qualifies — side projects included.
+We only skip entries that are dead links, NSFW, or pure landing pages with no
+product behind them.

--- a/README.md
+++ b/README.md
@@ -233,9 +233,9 @@ see the [showcase guidelines](CONTRIBUTING.md#add-your-project-to-the-showcase))
 
 ## Sponsors
 
-Quickdraw is MIT-licensed with no paid tier — [sponsors](https://tryquickdraw.com/sponsors/)
-are what keep it that way. Gold and Silver sponsors get their logo here and on
-the website:
+Quickdraw is MIT-licensed with no paid tier — [sponsors](https://github.com/sponsors/quickdrawjs)
+are what keep it that way. Sponsors get their logo on
+[the website](https://tryquickdraw.com/sponsors/) and here:
 
 <a href="https://tryquickdraw.com/sponsors/"><i>No sponsors yet — your logo could be the first.</i></a>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quickdraw
 
-[![CI](https://github.com/nmndwivedi/quickdraw/actions/workflows/ci.yml/badge.svg)](https://github.com/nmndwivedi/quickdraw/actions/workflows/ci.yml)
+[![CI](https://github.com/quickdrawjs/quickdraw/actions/workflows/ci.yml/badge.svg)](https://github.com/quickdrawjs/quickdraw/actions/workflows/ci.yml)
 [![npm: @quickdrawjs/core](https://img.shields.io/npm/v/@quickdrawjs/core?label=%40quickdrawjs%2Fcore&logo=npm)](https://www.npmjs.com/package/@quickdrawjs/core)
 [![npm: @quickdrawjs/react](https://img.shields.io/npm/v/@quickdrawjs/react?label=%40quickdrawjs%2Freact&logo=npm)](https://www.npmjs.com/package/@quickdrawjs/react)
 [![npm: @quickdrawjs/react-native](https://img.shields.io/npm/v/@quickdrawjs/react-native?label=%40quickdrawjs%2Freact-native&logo=npm)](https://www.npmjs.com/package/@quickdrawjs/react-native)
@@ -217,7 +217,7 @@ npm run typecheck # validate the published type declarations
 Quickdraw is young. What it doesn't have yet: a first-party multiplayer
 server (the diff-based store is sync-ready — you bring the transport),
 layers, frames, or rich text. The full roadmap lives in
-[issue #1](https://github.com/nmndwivedi/quickdraw/issues/1) — comment there
+[issue #1](https://github.com/quickdrawjs/quickdraw/issues/1) — comment there
 if the missing feature that sent you back to a paid SDK is on it (or isn't).
 
 ## Made with Quickdraw
@@ -244,7 +244,7 @@ the website:
 Quickdraw is free forever — no license fees, no upsell. If it saves you one, a
 star is how other developers find it.
 
-<a href="https://github.com/nmndwivedi/quickdraw/stargazers">
+<a href="https://github.com/quickdrawjs/quickdraw/stargazers">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/star-history-dark.svg">
     <source media="(prefers-color-scheme: light)" srcset="docs/star-history.svg">
@@ -260,8 +260,8 @@ same data as the chart on <a href="https://tryquickdraw.com/#support">the websit
 
 Quickdraw is open to contributions from everyone — bug reports, features,
 docs, examples. Start with [CONTRIBUTING.md](CONTRIBUTING.md), browse
-[`good first issue`](https://github.com/nmndwivedi/quickdraw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22),
-or open a [discussion](https://github.com/nmndwivedi/quickdraw/discussions)
+[`good first issue`](https://github.com/quickdrawjs/quickdraw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22),
+or open a [discussion](https://github.com/quickdrawjs/quickdraw/discussions)
 if you're not sure where a change belongs. We follow the
 [Contributor Covenant](CODE_OF_CONDUCT.md).
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,25 @@ layers, frames, or rich text. The full roadmap lives in
 [issue #1](https://github.com/nmndwivedi/quickdraw/issues/1) — comment there
 if the missing feature that sent you back to a paid SDK is on it (or isn't).
 
+## Made with Quickdraw
+
+Projects and products built on Quickdraw. Shipped something? **Add it here** —
+edit this table and open a PR (one row, alphabetical, ≤ 15-word description;
+see the [showcase guidelines](CONTRIBUTING.md#add-your-project-to-the-showcase)).
+
+| Project | Description |
+| --- | --- |
+| [tryquickdraw.com/app](https://app.tryquickdraw.com) | The official free whiteboard app — no account, autosaves locally. |
+| _Your project here_ | [Add yours →](CONTRIBUTING.md#add-your-project-to-the-showcase) |
+
+## Sponsors
+
+Quickdraw is MIT-licensed with no paid tier — [sponsors](https://tryquickdraw.com/sponsors/)
+are what keep it that way. Gold and Silver sponsors get their logo here and on
+the website:
+
+<a href="https://tryquickdraw.com/sponsors/"><i>No sponsors yet — your logo could be the first.</i></a>
+
 ## Star history
 
 Quickdraw is free forever — no license fees, no upsell. If it saves you one, a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ security fixes.
 Please **do not open a public issue** for security problems.
 
 Report privately via
-[GitHub Security Advisories](https://github.com/nmndwivedi/quickdraw/security/advisories/new)
+[GitHub Security Advisories](https://github.com/quickdrawjs/quickdraw/security/advisories/new)
 or email **promptifyapps@gmail.com**.
 
 You can expect an acknowledgment within a few days. Once a fix ships we'll

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -16,57 +16,65 @@
   <style>
     html, body { margin: 0; height: 100%; overscroll-behavior: none; }
     #board { position: fixed; inset: 0; }
-    /* The wordmark — quiet ink on the paper, top left, links home. */
+    /* Top-left chrome — the wordmark and the file bar share the dock's dark
+       glass, so every bar on the canvas stays dark in both themes. */
     .qd-app-logo {
-      position: fixed; left: 14px; top: 12px; z-index: 60;
+      position: fixed; left: 10px; top: 10px; z-index: 60;
       display: flex; align-items: center; gap: 8px;
-      font: 700 16px/1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+      font: 700 15.5px/1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
       letter-spacing: -0.01em;
-      color: #1c1b18; text-decoration: none;
-      padding: 6px 10px; border-radius: 10px;
+      color: rgba(255, 255, 255, 0.92); text-decoration: none;
+      padding: 8px 14px 8px 11px; border-radius: 999px;
+      background: rgba(19, 17, 13, 0.72);
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      box-shadow: 0 4px 16px rgba(10, 8, 4, 0.25);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
       -webkit-tap-highlight-color: transparent;
-      transition: background 140ms ease, color 140ms ease;
+      transition: background 140ms ease;
     }
-    .qd-app-logo svg { width: 21px; height: 21px; display: block; }
-    .qd-app-logo:hover { background: rgba(28, 27, 24, 0.06); }
-    .qd-app-logo.dark { color: #f4f2ea; }
-    .qd-app-logo.dark:hover { background: rgba(244, 242, 234, 0.08); }
+    .qd-app-logo svg { width: 20px; height: 20px; display: block; }
+    .qd-app-logo:hover { background: rgba(19, 17, 13, 0.85); }
 
     /* File bar — files menu, new file, and the current file's name. */
     .qd-filebar {
-      position: fixed; left: 148px; top: 12px; z-index: 60;
+      position: fixed; left: 152px; top: 10px; z-index: 60;
       display: flex; align-items: center; gap: 2px;
+      padding: 4px 6px; border-radius: 999px;
       font: 500 14px/1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-      color: #1c1b18;
-    }
-    .qd-filebar::before {
-      content: ''; width: 1px; height: 18px; background: rgba(28, 27, 24, 0.16);
-      margin-right: 8px;
+      color: rgba(255, 255, 255, 0.85);
+      background: rgba(19, 17, 13, 0.72);
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      box-shadow: 0 4px 16px rgba(10, 8, 4, 0.25);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
     }
     .qd-file-btn {
       appearance: none; border: none; background: transparent; color: inherit;
       display: flex; align-items: center; justify-content: center;
-      width: 32px; height: 32px; border-radius: 9px; cursor: pointer;
+      width: 30px; height: 30px; border-radius: 999px; cursor: pointer;
       -webkit-tap-highlight-color: transparent;
       transition: background 140ms ease;
     }
     .qd-file-btn svg { width: 17px; height: 17px; display: block; }
-    .qd-file-btn:hover { background: rgba(28, 27, 24, 0.07); }
+    .qd-file-btn:hover { background: rgba(255, 255, 255, 0.1); }
     .qd-file-name {
       appearance: none; border: none; background: transparent; color: inherit;
       font: inherit; font-weight: 600; letter-spacing: -0.005em;
-      margin-left: 4px; padding: 7px 10px; border-radius: 9px;
+      margin-left: 2px; padding: 7px 10px; border-radius: 999px;
       min-width: 40px; max-width: 200px; cursor: text;
       transition: background 140ms ease;
     }
-    .qd-file-name:hover { background: rgba(28, 27, 24, 0.06); }
-    .qd-file-name:focus { outline: none; background: rgba(28, 27, 24, 0.08); }
+    .qd-file-name:hover { background: rgba(255, 255, 255, 0.08); }
+    .qd-file-name:focus { outline: none; background: rgba(255, 255, 255, 0.12); }
     .qd-files-menu {
-      position: fixed; left: 156px; top: 52px; z-index: 70;
+      position: fixed; left: 156px; top: 54px; z-index: 70;
       min-width: 230px; max-height: 60vh; overflow-y: auto;
-      background: #fff; color: #1c1b18;
-      border: 1px solid rgba(28, 27, 24, 0.12); border-radius: 12px;
-      box-shadow: 0 14px 40px -12px rgba(28, 27, 24, 0.3);
+      background: rgba(19, 17, 13, 0.85); color: rgba(255, 255, 255, 0.88);
+      border: 1px solid rgba(255, 255, 255, 0.14); border-radius: 13px;
+      box-shadow: 0 8px 28px rgba(10, 8, 4, 0.35);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
       padding: 6px;
     }
     .qd-files-menu[hidden] { display: none; }
@@ -75,35 +83,24 @@
       padding: 8px 10px; border-radius: 8px; cursor: pointer;
       font: 500 14px/1.2 inherit;
     }
-    .qd-file-row:hover { background: rgba(28, 27, 24, 0.06); }
+    .qd-file-row:hover { background: rgba(255, 255, 255, 0.1); }
     .qd-file-row .name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .qd-file-row.current .name { font-weight: 700; }
     .qd-file-row .dot { width: 6px; height: 6px; border-radius: 999px; background: transparent; flex: none; }
-    .qd-file-row.current .dot { background: #2f6fed; }
+    .qd-file-row.current .dot { background: #6285f5; }
     .qd-file-row .del {
       appearance: none; border: none; background: transparent; cursor: pointer;
-      color: rgba(28, 27, 24, 0.4); border-radius: 6px; flex: none;
+      color: rgba(255, 255, 255, 0.45); border-radius: 6px; flex: none;
       width: 22px; height: 22px; display: flex; align-items: center; justify-content: center;
       font: 600 14px/1 inherit; padding: 0;
     }
-    .qd-file-row .del:hover { color: #c0392b; background: rgba(192, 57, 43, 0.1); }
-
-    /* Dark theme follows the board, same as the logo. */
-    .dark .qd-filebar, .qd-filebar.dark { color: #f4f2ea; }
-    .qd-filebar.dark::before { background: rgba(244, 242, 234, 0.22); }
-    .qd-filebar.dark .qd-file-btn:hover,
-    .qd-filebar.dark .qd-file-name:hover { background: rgba(244, 242, 234, 0.09); }
-    .qd-filebar.dark .qd-file-name:focus { background: rgba(244, 242, 234, 0.12); }
-    .qd-files-menu.dark {
-      background: #262624; color: #f4f2ea; border-color: rgba(244, 242, 234, 0.14);
-      box-shadow: 0 14px 40px -12px rgba(0, 0, 0, 0.6);
-    }
-    .qd-files-menu.dark .qd-file-row:hover { background: rgba(244, 242, 234, 0.08); }
-    .qd-files-menu.dark .qd-file-row .del { color: rgba(244, 242, 234, 0.45); }
-    .qd-files-menu.dark .qd-file-row .del:hover { color: #ff7b6b; background: rgba(255, 123, 107, 0.14); }
+    .qd-file-row .del:hover { color: #ff7b6b; background: rgba(255, 123, 107, 0.14); }
 
     @media (max-width: 560px) {
-      .qd-filebar { left: 128px; }
+      /* the wordmark folds to its glyph so the file bar fits beside it */
+      .qd-app-logo { padding: 8px 11px; }
+      .qd-app-logo .logo-word { display: none; }
+      .qd-filebar { left: 60px; }
       .qd-file-name { max-width: 110px; }
       .qd-files-menu { left: 14px; }
     }
@@ -116,7 +113,7 @@
       <path d="M7 21 C7 12, 13 6.5, 20 7.5 C26.5 8.5, 27.5 16, 22 18.8 C17.5 21, 13 19.5, 14 15" stroke="currentColor" stroke-width="3" stroke-linecap="round" fill="none"/>
       <circle cx="24.5" cy="24.5" r="2.6" fill="#2f6fed"/>
     </svg>
-    Quickdraw
+    <span class="logo-word">Quickdraw</span>
   </a>
   <div class="qd-filebar" id="filebar">
     <button class="qd-file-btn" id="files-btn" type="button" title="Your files" aria-label="Your files" aria-haspopup="true" aria-expanded="false">

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -16,25 +16,53 @@
   <style>
     html, body { margin: 0; height: 100%; overscroll-behavior: none; }
     #board { position: fixed; inset: 0; }
-    /* Top-left chrome — the wordmark and the file bar share the dock's dark
-       glass, so every bar on the canvas stays dark in both themes. */
+    /* Top-left chrome — the wordmark and the file bar follow the board's
+       theme, same glass recipe as the dock: light glass on light paper,
+       dark glass on dark. The 320ms transitions match the board's own
+       theme crossfade so the whole switch reads as one motion. */
+    :root {
+      --bar-bg: rgba(255, 255, 255, 0.88);
+      --bar-border: rgba(28, 27, 24, 0.12);
+      --bar-shadow: 0 4px 16px rgba(28, 27, 24, 0.14);
+      --bar-ink: rgba(28, 27, 24, 0.9);
+      --bar-hover: rgba(28, 27, 24, 0.07);
+      --menu-bg: rgba(255, 255, 255, 0.94);
+      --menu-shadow: 0 8px 28px rgba(28, 27, 24, 0.2);
+      --del-ink: rgba(28, 27, 24, 0.4);
+      --del-hot: #c0392b;
+      --del-hot-bg: rgba(192, 57, 43, 0.1);
+      --current-dot: #2f6fed;
+    }
+    :root.dark {
+      --bar-bg: rgba(19, 17, 13, 0.72);
+      --bar-border: rgba(255, 255, 255, 0.14);
+      --bar-shadow: 0 4px 16px rgba(10, 8, 4, 0.25);
+      --bar-ink: rgba(255, 255, 255, 0.9);
+      --bar-hover: rgba(255, 255, 255, 0.1);
+      --menu-bg: rgba(19, 17, 13, 0.85);
+      --menu-shadow: 0 8px 28px rgba(10, 8, 4, 0.35);
+      --del-ink: rgba(255, 255, 255, 0.45);
+      --del-hot: #ff7b6b;
+      --del-hot-bg: rgba(255, 123, 107, 0.14);
+      --current-dot: #6285f5;
+    }
     .qd-app-logo {
       position: fixed; left: 10px; top: 10px; z-index: 60;
       display: flex; align-items: center; gap: 8px;
       font: 700 15.5px/1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
       letter-spacing: -0.01em;
-      color: rgba(255, 255, 255, 0.92); text-decoration: none;
+      color: var(--bar-ink); text-decoration: none;
       padding: 8px 14px 8px 11px; border-radius: 999px;
-      background: rgba(19, 17, 13, 0.72);
-      border: 1px solid rgba(255, 255, 255, 0.14);
-      box-shadow: 0 4px 16px rgba(10, 8, 4, 0.25);
+      background: var(--bar-bg);
+      border: 1px solid var(--bar-border);
+      box-shadow: var(--bar-shadow);
       backdrop-filter: blur(10px);
       -webkit-backdrop-filter: blur(10px);
       -webkit-tap-highlight-color: transparent;
-      transition: background 140ms ease;
+      transition: background 320ms ease, color 320ms ease, border-color 320ms ease, box-shadow 320ms ease;
     }
     .qd-app-logo svg { width: 20px; height: 20px; display: block; }
-    .qd-app-logo:hover { background: rgba(19, 17, 13, 0.85); }
+    .qd-app-logo:hover { background: var(--bar-hover); }
 
     /* File bar — files menu, new file, and the current file's name. */
     .qd-filebar {
@@ -42,12 +70,13 @@
       display: flex; align-items: center; gap: 2px;
       padding: 4px 6px; border-radius: 999px;
       font: 500 14px/1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-      color: rgba(255, 255, 255, 0.85);
-      background: rgba(19, 17, 13, 0.72);
-      border: 1px solid rgba(255, 255, 255, 0.14);
-      box-shadow: 0 4px 16px rgba(10, 8, 4, 0.25);
+      color: var(--bar-ink);
+      background: var(--bar-bg);
+      border: 1px solid var(--bar-border);
+      box-shadow: var(--bar-shadow);
       backdrop-filter: blur(10px);
       -webkit-backdrop-filter: blur(10px);
+      transition: background 320ms ease, color 320ms ease, border-color 320ms ease, box-shadow 320ms ease;
     }
     .qd-file-btn {
       appearance: none; border: none; background: transparent; color: inherit;
@@ -57,7 +86,7 @@
       transition: background 140ms ease;
     }
     .qd-file-btn svg { width: 17px; height: 17px; display: block; }
-    .qd-file-btn:hover { background: rgba(255, 255, 255, 0.1); }
+    .qd-file-btn:hover { background: var(--bar-hover); }
     .qd-file-name {
       appearance: none; border: none; background: transparent; color: inherit;
       font: inherit; font-weight: 600; letter-spacing: -0.005em;
@@ -65,17 +94,18 @@
       min-width: 40px; max-width: 200px; cursor: text;
       transition: background 140ms ease;
     }
-    .qd-file-name:hover { background: rgba(255, 255, 255, 0.08); }
-    .qd-file-name:focus { outline: none; background: rgba(255, 255, 255, 0.12); }
+    .qd-file-name:hover { background: var(--bar-hover); }
+    .qd-file-name:focus { outline: none; background: var(--bar-hover); }
     .qd-files-menu {
       position: fixed; left: 156px; top: 54px; z-index: 70;
       min-width: 230px; max-height: 60vh; overflow-y: auto;
-      background: rgba(19, 17, 13, 0.85); color: rgba(255, 255, 255, 0.88);
-      border: 1px solid rgba(255, 255, 255, 0.14); border-radius: 13px;
-      box-shadow: 0 8px 28px rgba(10, 8, 4, 0.35);
+      background: var(--menu-bg); color: var(--bar-ink);
+      border: 1px solid var(--bar-border); border-radius: 13px;
+      box-shadow: var(--menu-shadow);
       backdrop-filter: blur(12px);
       -webkit-backdrop-filter: blur(12px);
       padding: 6px;
+      transition: background 320ms ease, color 320ms ease, border-color 320ms ease, box-shadow 320ms ease;
     }
     .qd-files-menu[hidden] { display: none; }
     .qd-files-menu .qd-file-row {
@@ -83,18 +113,18 @@
       padding: 8px 10px; border-radius: 8px; cursor: pointer;
       font: 500 14px/1.2 inherit;
     }
-    .qd-file-row:hover { background: rgba(255, 255, 255, 0.1); }
+    .qd-file-row:hover { background: var(--bar-hover); }
     .qd-file-row .name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .qd-file-row.current .name { font-weight: 700; }
     .qd-file-row .dot { width: 6px; height: 6px; border-radius: 999px; background: transparent; flex: none; }
-    .qd-file-row.current .dot { background: #6285f5; }
+    .qd-file-row.current .dot { background: var(--current-dot); }
     .qd-file-row .del {
       appearance: none; border: none; background: transparent; cursor: pointer;
-      color: rgba(255, 255, 255, 0.45); border-radius: 6px; flex: none;
+      color: var(--del-ink); border-radius: 6px; flex: none;
       width: 22px; height: 22px; display: flex; align-items: center; justify-content: center;
       font: 600 14px/1 inherit; padding: 0;
     }
-    .qd-file-row .del:hover { color: #ff7b6b; background: rgba(255, 123, 107, 0.14); }
+    .qd-file-row .del:hover { color: var(--del-hot); background: var(--del-hot-bg); }
 
     @media (max-width: 560px) {
       /* the wordmark folds to its glyph so the file bar fits beside it */

--- a/apps/app/src/main.js
+++ b/apps/app/src/main.js
@@ -224,11 +224,12 @@ nameInput.addEventListener('blur', () => {
 openFile(currentFile().id)
 sizeNameInput()
 
-// Remember the theme across visits. The chrome itself is always dark glass —
-// only the browser UI tint follows the paper.
+// Remember the theme across visits; the chrome follows the board through the
+// root .dark class (the CSS variables up in index.html key off it).
 const syncTheme = () => {
   const dark = editor.theme.id === 'dark'
   localStorage.setItem(THEME_KEY, editor.theme.id)
+  document.documentElement.classList.toggle('dark', dark)
   document.querySelector('meta[name="theme-color"]')
     ?.setAttribute('content', dark ? '#1e1e1c' : '#faf8f4')
 }

--- a/apps/app/src/main.js
+++ b/apps/app/src/main.js
@@ -224,14 +224,11 @@ nameInput.addEventListener('blur', () => {
 openFile(currentFile().id)
 sizeNameInput()
 
-// Remember the theme across visits; the chrome follows the board's colors.
-const logo = document.getElementById('logo')
+// Remember the theme across visits. The chrome itself is always dark glass —
+// only the browser UI tint follows the paper.
 const syncTheme = () => {
   const dark = editor.theme.id === 'dark'
   localStorage.setItem(THEME_KEY, editor.theme.id)
-  logo.classList.toggle('dark', dark)
-  filebar.classList.toggle('dark', dark)
-  menu.classList.toggle('dark', dark)
   document.querySelector('meta[name="theme-color"]')
     ?.setAttribute('content', dark ? '#1e1e1c' : '#faf8f4')
 }

--- a/apps/docs/app/layout.jsx
+++ b/apps/docs/app/layout.jsx
@@ -61,7 +61,7 @@ const navbar = (
   <Navbar
     logo={logo}
     logoLink="https://tryquickdraw.com"
-    projectLink="https://github.com/nmndwivedi/quickdraw"
+    projectLink="https://github.com/quickdrawjs/quickdraw"
   >
     {npmLink}
   </Navbar>
@@ -76,7 +76,7 @@ const footer = (
     <span>
       MIT licensed. Built in the open —{' '}
       <a
-        href="https://github.com/nmndwivedi/quickdraw"
+        href="https://github.com/quickdrawjs/quickdraw"
         target="_blank"
         rel="noreferrer"
         style={footerLink}
@@ -124,7 +124,7 @@ export default async function RootLayout({ children }) {
           navbar={navbar}
           footer={footer}
           pageMap={await getPageMap()}
-          docsRepositoryBase="https://github.com/nmndwivedi/quickdraw/edit/main/apps/docs"
+          docsRepositoryBase="https://github.com/quickdrawjs/quickdraw/edit/main/apps/docs"
           editLink="Edit this page on GitHub"
           sidebar={{ defaultMenuCollapseLevel: 2 }}
         >

--- a/apps/website/src/components/SponsorWall.astro
+++ b/apps/website/src/components/SponsorWall.astro
@@ -1,0 +1,139 @@
+---
+// The sponsor wall — the one component both the homepage and /sponsors render.
+//
+// Empty, it's the pitch: a row of ghost logo slots with a live "your logo
+// here" slot, then the founding-sponsor invite and a CTA. Populated, it's a
+// flat row of avatar chips (synced daily from GitHub Sponsors) with the
+// dashed slot as the standing invite; pass `cap` to bound the row and roll
+// the rest into "+N more on GitHub →".
+import { SPONSOR_URL, sponsors } from '../lib/sponsors.js'
+
+const { cap } = Astro.props
+const all = sponsors()
+const shown = cap ? all.slice(0, cap) : all
+const overflow = all.length - shown.length
+const empty = all.length === 0
+
+// Ghost slots fade out to the right, so the space reads as "waiting for
+// logos", not "broken".
+const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
+---
+{empty ? (
+  <div class="wall empty">
+    <div class="ghost-grid" aria-hidden="true">
+      <a class="slot your-slot" href={SPONSOR_URL} rel="noopener">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+        Your logo here
+      </a>
+      {ghosts.map((o) => (
+        <div class="slot ghost" style={`--o: ${o}`}></div>
+      ))}
+    </div>
+    <div class="pitch">
+      <svg class="heart" viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21s-7.5-4.6-9.5-9.2C1 8 3.2 4.6 6.8 4.6c2.2 0 3.9 1.2 5.2 3 1.3-1.8 3-3 5.2-3 3.6 0 5.8 3.4 4.3 7.2C19.5 16.4 12 21 12 21Z"/></svg>
+      <p class="pitch-title">Nobody's here yet.</p>
+      <p class="pitch-copy">
+        The first sponsors get the one thing money usually can't buy on a
+        sponsor wall: being first. Founding sponsors stay marked as such for
+        the life of the project.
+      </p>
+      <a class="btn" href={SPONSOR_URL} rel="noopener">Claim the first spot</a>
+    </div>
+  </div>
+) : (
+  <div class="wall">
+    <div class="row">
+      {shown.map((s) => (
+        <a class="chip" href={s.url} rel="noopener sponsored" title={s.name}>
+          {s.logo
+            ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
+            : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
+        </a>
+      ))}
+      <a class="slot your-slot small" href={SPONSOR_URL} rel="noopener">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+        Your logo
+      </a>
+    </div>
+    {overflow > 0 && (
+      <p class="more"><a href={SPONSOR_URL} rel="noopener">+ {overflow} more sponsor{overflow === 1 ? '' : 's'} on GitHub →</a></p>
+    )}
+  </div>
+)}
+
+<style>
+  .wall {
+    background: #fff; border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 26px 26px 22px;
+  }
+  .wall.empty { border-style: dashed; border-width: 1.5px; padding-bottom: 34px; }
+
+  .ghost-grid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 12px;
+  }
+  .slot {
+    display: flex; align-items: center; justify-content: center; gap: 8px;
+    height: 64px; border-radius: 12px;
+    border: 1.5px dashed var(--line);
+    color: var(--ink-soft); font-weight: 600; font-size: 13.5px;
+  }
+  .slot.ghost { opacity: var(--o, 1); }
+  .your-slot {
+    border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+    color: color-mix(in srgb, var(--accent) 75%, var(--ink));
+    background: color-mix(in srgb, var(--accent) 4%, transparent);
+    text-decoration: none;
+    transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+  }
+  .your-slot:hover {
+    background: color-mix(in srgb, var(--accent) 9%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 70%, transparent);
+    transform: translateY(-2px); text-decoration: none;
+  }
+
+  .pitch { text-align: center; margin-top: 30px; }
+  .heart { color: color-mix(in srgb, var(--accent) 70%, var(--ink)); margin-bottom: 6px; }
+  .pitch-title { font-weight: 700; font-size: 18px; margin: 0 0 8px; color: var(--ink); }
+  .pitch-copy {
+    color: var(--ink-soft); max-width: 52ch; margin: 0 auto 22px;
+    text-wrap: pretty; line-height: 1.6;
+  }
+  .btn {
+    display: inline-block; padding: 11px 22px; border-radius: 999px; font-weight: 600;
+    background: var(--ink); color: var(--paper); font-size: 15.5px;
+  }
+  .btn:hover { text-decoration: none; background: #000; }
+
+  .row { display: flex; flex-wrap: wrap; gap: 12px; align-items: stretch; }
+  .chip {
+    display: flex; align-items: center; justify-content: center; gap: 9px;
+    height: 60px; padding: 0 20px;
+    border: 1px solid var(--line); border-radius: 12px; background: #fff;
+    text-decoration: none;
+    transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
+  }
+  .chip:hover {
+    transform: translateY(-2px); text-decoration: none;
+    border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
+    box-shadow: 0 12px 26px -18px rgba(28, 27, 24, 0.5);
+  }
+  .chip .logo { max-height: 34px; max-width: 140px; object-fit: contain; display: block; }
+  .chip .avatar { width: 28px; height: 28px; border-radius: 50%; display: block; }
+  .chip-name { font-weight: 700; font-size: 14.5px; color: var(--ink); letter-spacing: -0.01em; }
+  .slot.small { height: 60px; flex: none; padding: 0 18px; }
+
+  .more { margin: 12px 0 0; font-size: 14px; }
+
+  @media (max-width: 640px) {
+    .wall { padding: 18px 16px 16px; }
+    .wall.empty { padding-bottom: 26px; }
+    .ghost-grid { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
+    .slot.ghost:nth-child(n + 4) { display: none; }
+    .pitch { margin-top: 22px; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .chip, .your-slot { transition: none; }
+    .chip:hover, .your-slot:hover { transform: none; }
+  }
+</style>

--- a/apps/website/src/components/SponsorWall.astro
+++ b/apps/website/src/components/SponsorWall.astro
@@ -1,10 +1,15 @@
 ---
 // The sponsor wall — one component, two placements:
 //
-//   <SponsorWall cap={8} compact />   homepage teaser: top sponsors, every
-//                                     link goes to /sponsors (the pitch page)
-//   <SponsorWall />                   /sponsors: the full wall, links go
-//                                     straight to GitHub Sponsors checkout
+//   <SponsorWall cap={8} toPage />   homepage: top sponsors, every link goes
+//                                    to /sponsors (the pitch page)
+//   <SponsorWall />                  /sponsors: the full wall, links go
+//                                    straight to GitHub Sponsors checkout
+//
+// Everything is centered on the card's axis: the empty state fades ghost
+// slots out symmetrically from the live "your logo here" slot in the middle,
+// and the populated row centers too, so a half-full row never reads as
+// left-over space.
 //
 // The wall simply mirrors GitHub Sponsors: active sponsors are on it, lapsed
 // ones roll off at the next daily sync, one-time donations age out when
@@ -12,47 +17,39 @@
 // placement promises — the copy only claims what the sync actually delivers.
 import { SPONSOR_URL, sponsors } from '../lib/sponsors.js'
 
-const { cap, compact = false } = Astro.props
-const href = compact ? '/sponsors/' : SPONSOR_URL
-const rel = compact ? undefined : 'noopener'
+const { cap, toPage = false } = Astro.props
+const href = toPage ? '/sponsors/' : SPONSOR_URL
+const rel = toPage ? undefined : 'noopener'
 
 const all = sponsors()
 const shown = cap ? all.slice(0, cap) : all
 const overflow = all.length - shown.length
 const empty = all.length === 0
 
-// Ghost slots fade out to the right, so the space reads as "waiting for
-// logos", not "broken".
-const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
+// Ghosts fade away from the live slot in both directions, so the invite sits
+// at the optical center of the row.
+const ghostsLeft = [0.2, 0.45]
+const ghostsRight = [0.45, 0.2]
 ---
 {empty ? (
   <div class="wall empty">
-    <div class="ghost-grid" aria-hidden="true">
+    <div class="ghost-row">
+      {ghostsLeft.map((o) => <div class="slot ghost" style={`--o: ${o}`} aria-hidden="true"></div>)}
       <a class="slot your-slot" href={href} rel={rel}>
-        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
         Your logo here
       </a>
-      {ghosts.map((o) => (
-        <div class="slot ghost" style={`--o: ${o}`}></div>
-      ))}
+      {ghostsRight.map((o) => <div class="slot ghost" style={`--o: ${o}`} aria-hidden="true"></div>)}
     </div>
-    {compact ? (
-      <p class="teaser-note">
-        The wall is empty — be the first on it.
-        <a href={href}>Become a sponsor →</a>
+    <div class="pitch">
+      <svg class="heart" viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21s-7.5-4.6-9.5-9.2C1 8 3.2 4.6 6.8 4.6c2.2 0 3.9 1.2 5.2 3 1.3-1.8 3-3 5.2-3 3.6 0 5.8 3.4 4.3 7.2C19.5 16.4 12 21 12 21Z"/></svg>
+      <p class="pitch-title">Nobody's here yet.</p>
+      <p class="pitch-copy">
+        Sponsor Quickdraw today and you're on this wall tomorrow — in front of
+        every developer sizing up a whiteboard SDK.
       </p>
-    ) : (
-      <div class="pitch">
-        <svg class="heart" viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21s-7.5-4.6-9.5-9.2C1 8 3.2 4.6 6.8 4.6c2.2 0 3.9 1.2 5.2 3 1.3-1.8 3-3 5.2-3 3.6 0 5.8 3.4 4.3 7.2C19.5 16.4 12 21 12 21Z"/></svg>
-        <p class="pitch-title">Nobody's here yet.</p>
-        <p class="pitch-copy">
-          Sponsor Quickdraw today and you're on this wall tomorrow — and on
-          the homepage, in front of every developer sizing up a whiteboard
-          SDK. An empty wall means the first logos get all the attention.
-        </p>
-        <a class="btn" href={href} rel={rel}>Claim the first spot</a>
-      </div>
-    )}
+      <a class="btn" href={href} rel={rel}>Claim the first spot</a>
+    </div>
   </div>
 ) : (
   <div class="wall">
@@ -61,7 +58,12 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
         <a class="chip" href={s.url} rel="noopener sponsored" title={s.name}>
           {s.logo
             ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
-            : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
+            : <>
+                {/* a dead avatar URL drops out rather than leaving a broken
+                    glyph — the name alone still reads as a finished chip */}
+                {s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" onerror="this.remove()" />}
+                <span class="chip-name">{s.name}</span>
+              </>}
         </a>
       ))}
       <a class="slot your-slot small" href={href} rel={rel}>
@@ -78,17 +80,20 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
 <style>
   .wall {
     background: #fff; border: 1px solid var(--line); border-radius: var(--radius);
-    padding: 26px 26px 22px;
+    padding: 26px 26px 24px;
+    text-align: center;
   }
-  .wall.empty { border-style: dashed; border-width: 1.5px; }
+  .wall.empty { border-style: dashed; border-width: 1.5px; padding-bottom: 34px; }
 
-  .ghost-grid {
-    display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 12px;
+  /* the ghost row scrolls out of view rather than wrapping — the fade only
+     reads as a fade while the slots stay on one line */
+  .ghost-row {
+    display: flex; justify-content: center; gap: 12px;
+    overflow: hidden;
   }
   .slot {
     display: flex; align-items: center; justify-content: center; gap: 8px;
-    height: 64px; border-radius: 12px;
+    flex: 0 0 172px; height: 64px; border-radius: 12px;
     border: 1.5px dashed var(--line);
     color: var(--ink-soft); font-weight: 600; font-size: 13.5px;
   }
@@ -106,18 +111,12 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
     transform: translateY(-2px); text-decoration: none;
   }
 
-  .teaser-note {
-    margin: 16px 0 0; text-align: center;
-    color: var(--ink-soft); font-size: 14px;
-  }
-  .teaser-note a { margin-left: 6px; font-weight: 600; }
-
-  .pitch { text-align: center; margin-top: 30px; padding-bottom: 12px; }
+  .pitch { margin-top: 30px; }
   .heart { color: color-mix(in srgb, var(--accent) 70%, var(--ink)); margin-bottom: 6px; }
   .pitch-title { font-weight: 700; font-size: 18px; margin: 0 0 8px; color: var(--ink); }
   .pitch-copy {
-    color: var(--ink-soft); max-width: 54ch; margin: 0 auto 22px;
-    text-wrap: pretty; line-height: 1.6;
+    color: var(--ink-soft); max-width: 50ch; margin: 0 auto 22px;
+    text-wrap: balance; line-height: 1.6;
   }
   .btn {
     display: inline-block; padding: 11px 22px; border-radius: 999px; font-weight: 600;
@@ -125,7 +124,7 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
   }
   .btn:hover { text-decoration: none; background: #000; }
 
-  .row { display: flex; flex-wrap: wrap; gap: 12px; align-items: stretch; }
+  .row { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; }
   .chip {
     display: flex; align-items: center; justify-content: center; gap: 9px;
     height: 60px; padding: 0 20px; max-width: 100%;
@@ -144,14 +143,14 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
     font-weight: 700; font-size: 14.5px; color: var(--ink); letter-spacing: -0.01em;
     max-width: 20ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
-  .slot.small { height: 60px; flex: none; padding: 0 18px; }
+  .slot.small { flex: none; height: 60px; padding: 0 18px; }
 
-  .more { margin: 12px 0 0; font-size: 14px; }
+  .more { margin: 14px 0 0; font-size: 14px; }
 
   @media (max-width: 640px) {
-    .wall { padding: 18px 16px 16px; }
-    .ghost-grid { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
-    .slot.ghost:nth-child(n + 4) { display: none; }
+    .wall { padding: 18px 16px 18px; }
+    .wall.empty { padding-bottom: 26px; }
+    .slot { flex-basis: 140px; }
     .pitch { margin-top: 22px; }
   }
   @media (prefers-reduced-motion: reduce) {

--- a/apps/website/src/components/SponsorWall.astro
+++ b/apps/website/src/components/SponsorWall.astro
@@ -1,14 +1,21 @@
 ---
-// The sponsor wall — the one component both the homepage and /sponsors render.
+// The sponsor wall — one component, two placements:
 //
-// Empty, it's the pitch: a row of ghost logo slots with a live "your logo
-// here" slot, then the founding-sponsor invite and a CTA. Populated, it's a
-// flat row of avatar chips (synced daily from GitHub Sponsors) with the
-// dashed slot as the standing invite; pass `cap` to bound the row and roll
-// the rest into "+N more on GitHub →".
+//   <SponsorWall cap={8} compact />   homepage teaser: top sponsors, every
+//                                     link goes to /sponsors (the pitch page)
+//   <SponsorWall />                   /sponsors: the full wall, links go
+//                                     straight to GitHub Sponsors checkout
+//
+// The wall simply mirrors GitHub Sponsors: active sponsors are on it, lapsed
+// ones roll off at the next daily sync, one-time donations age out when
+// GitHub stops counting them as active. No hand-kept lists, no lifetime
+// placement promises — the copy only claims what the sync actually delivers.
 import { SPONSOR_URL, sponsors } from '../lib/sponsors.js'
 
-const { cap } = Astro.props
+const { cap, compact = false } = Astro.props
+const href = compact ? '/sponsors/' : SPONSOR_URL
+const rel = compact ? undefined : 'noopener'
+
 const all = sponsors()
 const shown = cap ? all.slice(0, cap) : all
 const overflow = all.length - shown.length
@@ -21,7 +28,7 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
 {empty ? (
   <div class="wall empty">
     <div class="ghost-grid" aria-hidden="true">
-      <a class="slot your-slot" href={SPONSOR_URL} rel="noopener">
+      <a class="slot your-slot" href={href} rel={rel}>
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
         Your logo here
       </a>
@@ -29,16 +36,23 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
         <div class="slot ghost" style={`--o: ${o}`}></div>
       ))}
     </div>
-    <div class="pitch">
-      <svg class="heart" viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21s-7.5-4.6-9.5-9.2C1 8 3.2 4.6 6.8 4.6c2.2 0 3.9 1.2 5.2 3 1.3-1.8 3-3 5.2-3 3.6 0 5.8 3.4 4.3 7.2C19.5 16.4 12 21 12 21Z"/></svg>
-      <p class="pitch-title">Nobody's here yet.</p>
-      <p class="pitch-copy">
-        The first sponsors get the one thing money usually can't buy on a
-        sponsor wall: being first. Founding sponsors stay marked as such for
-        the life of the project.
+    {compact ? (
+      <p class="teaser-note">
+        The wall is empty — be the first on it.
+        <a href={href}>Become a sponsor →</a>
       </p>
-      <a class="btn" href={SPONSOR_URL} rel="noopener">Claim the first spot</a>
-    </div>
+    ) : (
+      <div class="pitch">
+        <svg class="heart" viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21s-7.5-4.6-9.5-9.2C1 8 3.2 4.6 6.8 4.6c2.2 0 3.9 1.2 5.2 3 1.3-1.8 3-3 5.2-3 3.6 0 5.8 3.4 4.3 7.2C19.5 16.4 12 21 12 21Z"/></svg>
+        <p class="pitch-title">Nobody's here yet.</p>
+        <p class="pitch-copy">
+          Sponsor Quickdraw today and you're on this wall tomorrow — and on
+          the homepage, in front of every developer sizing up a whiteboard
+          SDK. An empty wall means the first logos get all the attention.
+        </p>
+        <a class="btn" href={href} rel={rel}>Claim the first spot</a>
+      </div>
+    )}
   </div>
 ) : (
   <div class="wall">
@@ -50,13 +64,13 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
             : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
         </a>
       ))}
-      <a class="slot your-slot small" href={SPONSOR_URL} rel="noopener">
+      <a class="slot your-slot small" href={href} rel={rel}>
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
         Your logo
       </a>
     </div>
     {overflow > 0 && (
-      <p class="more"><a href={SPONSOR_URL} rel="noopener">+ {overflow} more sponsor{overflow === 1 ? '' : 's'} on GitHub →</a></p>
+      <p class="more"><a href={href} rel={rel}>+ {overflow} more sponsor{overflow === 1 ? '' : 's'} →</a></p>
     )}
   </div>
 )}
@@ -66,7 +80,7 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
     background: #fff; border: 1px solid var(--line); border-radius: var(--radius);
     padding: 26px 26px 22px;
   }
-  .wall.empty { border-style: dashed; border-width: 1.5px; padding-bottom: 34px; }
+  .wall.empty { border-style: dashed; border-width: 1.5px; }
 
   .ghost-grid {
     display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
@@ -92,11 +106,17 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
     transform: translateY(-2px); text-decoration: none;
   }
 
-  .pitch { text-align: center; margin-top: 30px; }
+  .teaser-note {
+    margin: 16px 0 0; text-align: center;
+    color: var(--ink-soft); font-size: 14px;
+  }
+  .teaser-note a { margin-left: 6px; font-weight: 600; }
+
+  .pitch { text-align: center; margin-top: 30px; padding-bottom: 12px; }
   .heart { color: color-mix(in srgb, var(--accent) 70%, var(--ink)); margin-bottom: 6px; }
   .pitch-title { font-weight: 700; font-size: 18px; margin: 0 0 8px; color: var(--ink); }
   .pitch-copy {
-    color: var(--ink-soft); max-width: 52ch; margin: 0 auto 22px;
+    color: var(--ink-soft); max-width: 54ch; margin: 0 auto 22px;
     text-wrap: pretty; line-height: 1.6;
   }
   .btn {
@@ -108,7 +128,7 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
   .row { display: flex; flex-wrap: wrap; gap: 12px; align-items: stretch; }
   .chip {
     display: flex; align-items: center; justify-content: center; gap: 9px;
-    height: 60px; padding: 0 20px;
+    height: 60px; padding: 0 20px; max-width: 100%;
     border: 1px solid var(--line); border-radius: 12px; background: #fff;
     text-decoration: none;
     transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
@@ -119,15 +139,17 @@ const ghosts = [0.72, 0.52, 0.36, 0.24, 0.15]
     box-shadow: 0 12px 26px -18px rgba(28, 27, 24, 0.5);
   }
   .chip .logo { max-height: 34px; max-width: 140px; object-fit: contain; display: block; }
-  .chip .avatar { width: 28px; height: 28px; border-radius: 50%; display: block; }
-  .chip-name { font-weight: 700; font-size: 14.5px; color: var(--ink); letter-spacing: -0.01em; }
+  .chip .avatar { width: 28px; height: 28px; border-radius: 50%; display: block; flex: none; }
+  .chip-name {
+    font-weight: 700; font-size: 14.5px; color: var(--ink); letter-spacing: -0.01em;
+    max-width: 20ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
   .slot.small { height: 60px; flex: none; padding: 0 18px; }
 
   .more { margin: 12px 0 0; font-size: 14px; }
 
   @media (max-width: 640px) {
     .wall { padding: 18px 16px 16px; }
-    .wall.empty { padding-bottom: 26px; }
     .ghost-grid { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
     .slot.ghost:nth-child(n + 4) { display: none; }
     .pitch { margin-top: 22px; }

--- a/apps/website/src/components/SponsorWall.astro
+++ b/apps/website/src/components/SponsorWall.astro
@@ -86,11 +86,15 @@ const ghostsRight = [0.45, 0.2]
   }
   .wall.empty { border-style: dashed; border-width: 1.5px; padding-bottom: 34px; }
 
-  /* the ghost row scrolls out of view rather than wrapping — the fade only
-     reads as a fade while the slots stay on one line */
+  /* the ghost row runs off both edges rather than wrapping — the fade only
+     reads as a fade while the slots stay on one line. The padding/negative
+     margin pair gives the hover lift and its shadow room to breathe: overflow
+     clips at the padding edge, so the row still hides the ghosts sideways
+     without shaving the top of a lifted slot. */
   .ghost-row {
     display: flex; justify-content: center; gap: 12px;
     overflow: hidden;
+    padding: 10px 0; margin: -10px 0;
   }
   .slot {
     display: flex; align-items: center; justify-content: center; gap: 8px;

--- a/apps/website/src/components/SponsorWall.astro
+++ b/apps/website/src/components/SponsorWall.astro
@@ -1,10 +1,13 @@
 ---
 // The sponsor wall — one component, two placements:
 //
-//   <SponsorWall cap={8} toPage />   homepage: top sponsors, every link goes
-//                                    to /sponsors (the pitch page)
-//   <SponsorWall />                  /sponsors: the full wall, links go
-//                                    straight to GitHub Sponsors checkout
+//   <SponsorWall cap={8} />   homepage: top sponsors, the rest behind
+//                             "+N more →" on /sponsors
+//   <SponsorWall />           /sponsors: the full wall
+//
+// Every call to action — the "your logo" slots, the button — goes straight to
+// GitHub Sponsors from wherever it's rendered; the only link to /sponsors is
+// the overflow count, which is the one thing that page uniquely holds.
 //
 // Everything is centered on the card's axis: the empty state fades ghost
 // slots out symmetrically from the live "your logo here" slot in the middle,
@@ -17,9 +20,7 @@
 // placement promises — the copy only claims what the sync actually delivers.
 import { SPONSOR_URL, sponsors } from '../lib/sponsors.js'
 
-const { cap, toPage = false } = Astro.props
-const href = toPage ? '/sponsors/' : SPONSOR_URL
-const rel = toPage ? undefined : 'noopener'
+const { cap } = Astro.props
 
 const all = sponsors()
 const shown = cap ? all.slice(0, cap) : all
@@ -35,7 +36,7 @@ const ghostsRight = [0.45, 0.2]
   <div class="wall empty">
     <div class="ghost-row">
       {ghostsLeft.map((o) => <div class="slot ghost" style={`--o: ${o}`} aria-hidden="true"></div>)}
-      <a class="slot your-slot" href={href} rel={rel}>
+      <a class="slot your-slot" href={SPONSOR_URL} rel="noopener">
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
         Your logo here
       </a>
@@ -48,7 +49,7 @@ const ghostsRight = [0.45, 0.2]
         Sponsor Quickdraw today and you're on this wall tomorrow — in front of
         every developer sizing up a whiteboard SDK.
       </p>
-      <a class="btn" href={href} rel={rel}>Claim the first spot</a>
+      <a class="btn" href={SPONSOR_URL} rel="noopener">Claim the first spot</a>
     </div>
   </div>
 ) : (
@@ -66,13 +67,13 @@ const ghostsRight = [0.45, 0.2]
               </>}
         </a>
       ))}
-      <a class="slot your-slot small" href={href} rel={rel}>
+      <a class="slot your-slot small" href={SPONSOR_URL} rel="noopener">
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
         Your logo
       </a>
     </div>
     {overflow > 0 && (
-      <p class="more"><a href={href} rel={rel}>+ {overflow} more sponsor{overflow === 1 ? '' : 's'} →</a></p>
+      <p class="more"><a href="/sponsors/">+ {overflow} more sponsor{overflow === 1 ? '' : 's'} →</a></p>
     )}
   </div>
 )}

--- a/apps/website/src/components/Sponsors.astro
+++ b/apps/website/src/components/Sponsors.astro
@@ -1,19 +1,11 @@
 ---
-// The homepage sponsor wall — one flat list, no tiers, no prices. Empty, it
-// sells the spot itself with ghost slots; populated, it's a simple row of
-// sponsors plus a dashed "your logo" slot as the standing invite. Overflow
-// past the cap rolls up into "+N more →" pointing at /sponsors.
+// Homepage sponsors section — heading and lede around the shared wall.
+// The empty wall carries its own CTA, so the extra button only appears
+// once there are sponsors and the pitch card is gone.
+import SponsorWall from './SponsorWall.astro'
 import { SPONSOR_URL, sponsors } from '../lib/sponsors.js'
 
-const all = sponsors()
-const CAP = 11 // with the invite slot that's two tidy rows at desktop width
-const shown = all.slice(0, CAP)
-const overflow = all.length - shown.length
-const empty = all.length === 0
-
-// The empty wall: six ghost slots fading out to the right, so the space reads
-// as "waiting for logos", not "broken".
-const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
+const hasSponsors = sponsors().length > 0
 ---
 <section class="sponsors" id="sponsors">
   <h2>Sponsors keep it MIT</h2>
@@ -23,46 +15,13 @@ const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
     who lands here.
   </p>
 
-  {empty ? (
-    <div class="wall empty">
-      <div class="ghost-grid" aria-hidden="true">
-        <a class="slot your-slot" href={SPONSOR_URL} rel="noopener">
-          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
-          Your logo here
-        </a>
-        {ghosts.slice(1).map((o) => (
-          <div class="slot ghost" style={`--o: ${o}`}></div>
-        ))}
-      </div>
-      <p class="empty-note">
-        This wall is brand new — the first logos on it will be here a long,
-        long time.
-      </p>
-    </div>
-  ) : (
-    <div class="wall">
-      <div class="row">
-        {shown.map((s) => (
-          <a class="chip" href={s.url} rel="noopener sponsored" title={s.name}>
-            {s.logo
-              ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
-              : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
-          </a>
-        ))}
-        <a class="slot your-slot small" href={SPONSOR_URL} rel="noopener">
-          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
-          Your logo
-        </a>
-      </div>
-      {overflow > 0 && (
-        <p class="more"><a href={SPONSOR_URL} rel="noopener">+ {overflow} more sponsor{overflow === 1 ? '' : 's'} on GitHub →</a></p>
-      )}
+  <SponsorWall cap={11} />
+
+  {hasSponsors && (
+    <div class="sponsor-actions">
+      <a class="btn primary" href={SPONSOR_URL} rel="noopener">Become a sponsor</a>
     </div>
   )}
-
-  <div class="sponsor-actions">
-    <a class="btn primary" href={SPONSOR_URL} rel="noopener">Become a sponsor</a>
-  </div>
 </section>
 
 <style>
@@ -70,58 +29,6 @@ const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
   .sponsors { margin-top: 96px; }
   h2 { font-size: clamp(26px, 4vw, 34px); line-height: 1.2; margin: 0 0 24px; letter-spacing: -0.01em; }
   .section-lede { color: var(--ink-soft); max-width: 62ch; margin: -8px 0 26px; }
-
-  .wall {
-    background: #fff; border: 1px solid var(--line); border-radius: var(--radius);
-    padding: 26px 26px 22px;
-  }
-  .ghost-grid {
-    display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 12px;
-  }
-  .slot {
-    display: flex; align-items: center; justify-content: center; gap: 8px;
-    height: 64px; border-radius: 12px;
-    border: 1.5px dashed var(--line);
-    color: var(--ink-soft); font-weight: 600; font-size: 13.5px;
-  }
-  .slot.ghost { opacity: var(--o, 1); }
-  .your-slot {
-    border-color: color-mix(in srgb, var(--accent) 45%, transparent);
-    color: color-mix(in srgb, var(--accent) 75%, var(--ink));
-    background: color-mix(in srgb, var(--accent) 4%, transparent);
-    text-decoration: none;
-    transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
-  }
-  .your-slot:hover {
-    background: color-mix(in srgb, var(--accent) 9%, transparent);
-    border-color: color-mix(in srgb, var(--accent) 70%, transparent);
-    transform: translateY(-2px); text-decoration: none;
-  }
-  .empty-note {
-    margin: 18px 0 0; text-align: center;
-    color: var(--ink-soft); font-size: 14px;
-  }
-
-  .row { display: flex; flex-wrap: wrap; gap: 12px; align-items: stretch; }
-  .chip {
-    display: flex; align-items: center; justify-content: center; gap: 9px;
-    height: 60px; padding: 0 20px;
-    border: 1px solid var(--line); border-radius: 12px; background: #fff;
-    text-decoration: none;
-    transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
-  }
-  .chip:hover {
-    transform: translateY(-2px); text-decoration: none;
-    border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
-    box-shadow: 0 12px 26px -18px rgba(28, 27, 24, 0.5);
-  }
-  .chip .logo { max-height: 34px; max-width: 140px; object-fit: contain; display: block; }
-  .chip .avatar { width: 28px; height: 28px; border-radius: 50%; display: block; }
-  .chip-name { font-weight: 700; font-size: 14.5px; color: var(--ink); letter-spacing: -0.01em; }
-  .slot.small { height: 60px; flex: none; padding: 0 18px; }
-
-  .more { margin: 12px 0 0; font-size: 14px; }
 
   .sponsor-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 22px; }
   .btn {
@@ -134,16 +41,9 @@ const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
 
   @media (max-width: 640px) {
     .sponsors { margin-top: 68px; }
-    .wall { padding: 18px 16px 16px; }
-    .ghost-grid { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
-    .slot.ghost:nth-child(n + 5) { display: none; }
   }
   @media (max-width: 460px) {
     .sponsor-actions { display: grid; grid-template-columns: 1fr; gap: 10px; }
     .btn { text-align: center; }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .chip, .your-slot { transition: none; }
-    .chip:hover, .your-slot:hover { transform: none; }
   }
 </style>

--- a/apps/website/src/components/Sponsors.astro
+++ b/apps/website/src/components/Sponsors.astro
@@ -1,8 +1,8 @@
 ---
 // Homepage sponsors section — a teaser for the dedicated /sponsors page:
 // the top sponsors (by monthly amount) and every link pointing there. The
-// empty wall carries its own CTA, so the extra button only appears once
-// there are sponsors and the invite line is gone.
+// wall carries its own CTA when empty, so the extra button only appears
+// once there are sponsors and the pitch card is gone.
 import SponsorWall from './SponsorWall.astro'
 import { sponsors } from '../lib/sponsors.js'
 
@@ -12,11 +12,10 @@ const hasSponsors = sponsors().length > 0
   <h2>Sponsors keep it MIT</h2>
   <p class="section-lede">
     Quickdraw has no license fees and never will — sponsors are what make that
-    math work. Every sponsor gets a spot on this wall, seen by each developer
-    who lands here.
+    math work. Every sponsor gets a spot on this wall.
   </p>
 
-  <SponsorWall cap={8} compact />
+  <SponsorWall cap={8} toPage />
 
   {hasSponsors && (
     <div class="sponsor-actions">
@@ -26,12 +25,16 @@ const hasSponsors = sponsors().length > 0
 </section>
 
 <style>
-  /* index.astro's section rhythm is scoped to that file — restate it here */
-  .sponsors { margin-top: 96px; }
-  h2 { font-size: clamp(26px, 4vw, 34px); line-height: 1.2; margin: 0 0 24px; letter-spacing: -0.01em; }
-  .section-lede { color: var(--ink-soft); max-width: 62ch; margin: -8px 0 26px; }
+  /* index.astro's section rhythm is scoped to that file — restate it here.
+     The block centers on the wall's axis, like the support card above it. */
+  .sponsors { margin-top: 96px; text-align: center; }
+  h2 { font-size: clamp(26px, 4vw, 34px); line-height: 1.2; margin: 0 0 16px; letter-spacing: -0.01em; }
+  .section-lede {
+    color: var(--ink-soft); max-width: 56ch; margin: 0 auto 26px;
+    text-wrap: pretty;
+  }
 
-  .sponsor-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 22px; }
+  .sponsor-actions { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; margin-top: 22px; }
   .btn {
     display: inline-block; padding: 11px 22px; border-radius: 999px; font-weight: 600;
     border: 1.5px solid var(--ink); color: var(--ink); font-size: 15.5px;

--- a/apps/website/src/components/Sponsors.astro
+++ b/apps/website/src/components/Sponsors.astro
@@ -51,7 +51,9 @@ const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
         <div class="row gold-row">
           {gold.map((s) => (
             <a class="chip gold" href={s.url} rel="noopener sponsored" title={s.name}>
-              {s.logo ? <img src={s.logo} alt={s.name} loading="lazy" /> : <span class="chip-name">{s.name}</span>}
+              {s.logo
+                ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
+                : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
             </a>
           ))}
         </div>
@@ -60,7 +62,9 @@ const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
         <div class="row silver-row">
           {silverShown.map((s) => (
             <a class="chip silver" href={s.url} rel="noopener sponsored" title={s.name}>
-              {s.logo ? <img src={s.logo} alt={s.name} loading="lazy" /> : <span class="chip-name">{s.name}</span>}
+              {s.logo
+                ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
+                : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
             </a>
           ))}
           <a class="slot your-slot small" href={SPONSOR_URL} rel="noopener">
@@ -72,7 +76,7 @@ const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
       {backersShown.length > 0 && (
         <p class="backers">
           {backersShown.map((s, i) => (
-            <><a href={s.url} rel="noopener sponsored">{s.name}</a>{i < backersShown.length - 1 ? ', ' : ''}</>
+            <><a href={s.url} rel="noopener sponsored">{s.avatar && <img class="mini-avatar" src={s.avatar} alt="" loading="lazy" />}{s.name}</a>{i < backersShown.length - 1 ? ', ' : ''}</>
           ))}
         </p>
       )}
@@ -139,12 +143,19 @@ const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
     border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
     box-shadow: 0 12px 26px -18px rgba(28, 27, 24, 0.5);
   }
-  .chip.gold { height: 84px; min-width: 200px; }
-  .chip.silver { height: 60px; min-width: 150px; }
-  .chip img { max-height: 60%; max-width: 170px; object-fit: contain; display: block; }
-  .chip.silver img { max-width: 130px; }
+  .chip.gold { height: 84px; min-width: 200px; gap: 12px; }
+  .chip.silver { height: 60px; min-width: 150px; gap: 9px; }
+  .chip .logo { max-height: 60%; max-width: 170px; object-fit: contain; display: block; }
+  .chip.silver .logo { max-width: 130px; }
+  .chip .avatar { border-radius: 50%; display: block; }
+  .chip.gold .avatar { width: 40px; height: 40px; }
+  .chip.silver .avatar { width: 28px; height: 28px; }
   .chip-name { font-weight: 700; font-size: 16px; color: var(--ink); letter-spacing: -0.01em; }
   .chip.silver .chip-name { font-size: 14.5px; }
+  .mini-avatar {
+    width: 18px; height: 18px; border-radius: 50%;
+    vertical-align: -4px; margin-right: 5px; display: inline-block;
+  }
   .slot.small { height: 60px; min-width: 150px; flex: none; padding: 0 18px; }
 
   .backers { margin: 14px 0 0; color: var(--ink-soft); font-size: 14.5px; line-height: 1.9; }

--- a/apps/website/src/components/Sponsors.astro
+++ b/apps/website/src/components/Sponsors.astro
@@ -1,10 +1,11 @@
 ---
-// Homepage sponsors section — a teaser for the dedicated /sponsors page:
-// the top sponsors (by monthly amount) and every link pointing there. The
-// wall carries its own CTA when empty, so the extra button only appears
-// once there are sponsors and the pitch card is gone.
+// Homepage sponsors section — the top sponsors, with the rest behind the
+// wall's own "+N more →" link to /sponsors. Every call to action goes
+// straight to GitHub Sponsors. The wall carries its own CTA when empty, so
+// the extra button only appears once there are sponsors and the pitch card
+// is gone.
 import SponsorWall from './SponsorWall.astro'
-import { sponsors } from '../lib/sponsors.js'
+import { SPONSOR_URL, sponsors } from '../lib/sponsors.js'
 
 const hasSponsors = sponsors().length > 0
 ---
@@ -15,11 +16,11 @@ const hasSponsors = sponsors().length > 0
     math work. Every sponsor gets a spot on this wall.
   </p>
 
-  <SponsorWall cap={8} toPage />
+  <SponsorWall cap={8} />
 
   {hasSponsors && (
     <div class="sponsor-actions">
-      <a class="btn primary" href="/sponsors/">Become a sponsor</a>
+      <a class="btn primary" href={SPONSOR_URL} rel="noopener">Become a sponsor</a>
     </div>
   )}
 </section>

--- a/apps/website/src/components/Sponsors.astro
+++ b/apps/website/src/components/Sponsors.astro
@@ -1,0 +1,177 @@
+---
+// The homepage sponsor wall. Three states, all handled here:
+//   0 sponsors  — ghost slots that sell the spot itself
+//   a few       — real logos plus one dashed "your logo" slot as the invite
+//   too many    — tiers are capped and the rest roll up into "+N more →",
+//                 with the full wall living at /sponsors
+import { SPONSOR_URL, byTier, activeSponsors } from '../lib/sponsors.js'
+
+const gold = byTier('gold')
+const silver = byTier('silver')
+const backers = byTier('backer')
+
+const SILVER_CAP = 8
+const BACKER_CAP = 14
+const silverShown = silver.slice(0, SILVER_CAP)
+const backersShown = backers.slice(0, BACKER_CAP)
+const overflow = (silver.length - silverShown.length) + (backers.length - backersShown.length)
+const empty = activeSponsors().length === 0
+
+// The empty wall: six ghost slots fading out to the right, so the space reads
+// as "waiting for logos", not "broken".
+const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
+---
+<section class="sponsors" id="sponsors">
+  <h2>Sponsors keep it MIT</h2>
+  <p class="section-lede">
+    Quickdraw has no license fees and never will — sponsors are what make that
+    math work. Every sponsor gets a spot on this wall, seen by each developer
+    who lands here.
+  </p>
+
+  {empty ? (
+    <div class="wall empty">
+      <div class="ghost-grid" aria-hidden="true">
+        <a class="slot your-slot" href={SPONSOR_URL} rel="noopener">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+          Your logo here
+        </a>
+        {ghosts.slice(1).map((o) => (
+          <div class="slot ghost" style={`--o: ${o}`}></div>
+        ))}
+      </div>
+      <p class="empty-note">
+        This wall is brand new — the first logos on it will be here a long,
+        long time.
+      </p>
+    </div>
+  ) : (
+    <div class="wall">
+      {gold.length > 0 && (
+        <div class="row gold-row">
+          {gold.map((s) => (
+            <a class="chip gold" href={s.url} rel="noopener sponsored" title={s.name}>
+              {s.logo ? <img src={s.logo} alt={s.name} loading="lazy" /> : <span class="chip-name">{s.name}</span>}
+            </a>
+          ))}
+        </div>
+      )}
+      {silverShown.length > 0 && (
+        <div class="row silver-row">
+          {silverShown.map((s) => (
+            <a class="chip silver" href={s.url} rel="noopener sponsored" title={s.name}>
+              {s.logo ? <img src={s.logo} alt={s.name} loading="lazy" /> : <span class="chip-name">{s.name}</span>}
+            </a>
+          ))}
+          <a class="slot your-slot small" href={SPONSOR_URL} rel="noopener">
+            <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+            Your logo
+          </a>
+        </div>
+      )}
+      {backersShown.length > 0 && (
+        <p class="backers">
+          {backersShown.map((s, i) => (
+            <><a href={s.url} rel="noopener sponsored">{s.name}</a>{i < backersShown.length - 1 ? ', ' : ''}</>
+          ))}
+        </p>
+      )}
+      {overflow > 0 && (
+        <p class="more"><a href="/sponsors/">+ {overflow} more sponsor{overflow === 1 ? '' : 's'} →</a></p>
+      )}
+    </div>
+  )}
+
+  <div class="sponsor-actions">
+    <a class="btn primary" href={SPONSOR_URL} rel="noopener">Become a sponsor</a>
+    <a class="btn" href="/sponsors/">See the tiers</a>
+  </div>
+</section>
+
+<style>
+  /* index.astro's section rhythm is scoped to that file — restate it here */
+  .sponsors { margin-top: 96px; }
+  h2 { font-size: clamp(26px, 4vw, 34px); line-height: 1.2; margin: 0 0 24px; letter-spacing: -0.01em; }
+  .section-lede { color: var(--ink-soft); max-width: 62ch; margin: -8px 0 26px; }
+
+  .wall {
+    background: #fff; border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 26px 26px 22px;
+  }
+  .ghost-grid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 12px;
+  }
+  .slot {
+    display: flex; align-items: center; justify-content: center; gap: 8px;
+    height: 64px; border-radius: 12px;
+    border: 1.5px dashed var(--line);
+    color: var(--ink-soft); font-weight: 600; font-size: 13.5px;
+  }
+  .slot.ghost { opacity: var(--o, 1); }
+  .your-slot {
+    border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+    color: color-mix(in srgb, var(--accent) 75%, var(--ink));
+    background: color-mix(in srgb, var(--accent) 4%, transparent);
+    text-decoration: none;
+    transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+  }
+  .your-slot:hover {
+    background: color-mix(in srgb, var(--accent) 9%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 70%, transparent);
+    transform: translateY(-2px); text-decoration: none;
+  }
+  .empty-note {
+    margin: 18px 0 0; text-align: center;
+    color: var(--ink-soft); font-size: 14px;
+  }
+
+  .row { display: flex; flex-wrap: wrap; gap: 12px; align-items: stretch; }
+  .row + .row, .row + .backers, .backers + .more { margin-top: 14px; }
+  .chip {
+    display: flex; align-items: center; justify-content: center;
+    border: 1px solid var(--line); border-radius: 12px; background: #fff;
+    padding: 0 22px; text-decoration: none;
+    transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
+  }
+  .chip:hover {
+    transform: translateY(-2px); text-decoration: none;
+    border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
+    box-shadow: 0 12px 26px -18px rgba(28, 27, 24, 0.5);
+  }
+  .chip.gold { height: 84px; min-width: 200px; }
+  .chip.silver { height: 60px; min-width: 150px; }
+  .chip img { max-height: 60%; max-width: 170px; object-fit: contain; display: block; }
+  .chip.silver img { max-width: 130px; }
+  .chip-name { font-weight: 700; font-size: 16px; color: var(--ink); letter-spacing: -0.01em; }
+  .chip.silver .chip-name { font-size: 14.5px; }
+  .slot.small { height: 60px; min-width: 150px; flex: none; padding: 0 18px; }
+
+  .backers { margin: 14px 0 0; color: var(--ink-soft); font-size: 14.5px; line-height: 1.9; }
+  .backers a { color: inherit; font-weight: 600; }
+  .more { margin: 12px 0 0; font-size: 14px; }
+
+  .sponsor-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 22px; }
+  .btn {
+    display: inline-block; padding: 11px 22px; border-radius: 999px; font-weight: 600;
+    border: 1.5px solid var(--ink); color: var(--ink); font-size: 15.5px;
+  }
+  .btn:hover { text-decoration: none; background: var(--paper-2); }
+  .btn.primary { background: var(--ink); color: var(--paper); }
+  .btn.primary:hover { background: #000; }
+
+  @media (max-width: 640px) {
+    .sponsors { margin-top: 68px; }
+    .wall { padding: 18px 16px 16px; }
+    .ghost-grid { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
+    .slot.ghost:nth-child(n + 5) { display: none; }
+  }
+  @media (max-width: 460px) {
+    .sponsor-actions { display: grid; grid-template-columns: 1fr; gap: 10px; }
+    .btn { text-align: center; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .chip, .your-slot { transition: none; }
+    .chip:hover, .your-slot:hover { transform: none; }
+  }
+</style>

--- a/apps/website/src/components/Sponsors.astro
+++ b/apps/website/src/components/Sponsors.astro
@@ -1,9 +1,10 @@
 ---
-// Homepage sponsors section — heading and lede around the shared wall.
-// The empty wall carries its own CTA, so the extra button only appears
-// once there are sponsors and the pitch card is gone.
+// Homepage sponsors section — a teaser for the dedicated /sponsors page:
+// the top sponsors (by monthly amount) and every link pointing there. The
+// empty wall carries its own CTA, so the extra button only appears once
+// there are sponsors and the invite line is gone.
 import SponsorWall from './SponsorWall.astro'
-import { SPONSOR_URL, sponsors } from '../lib/sponsors.js'
+import { sponsors } from '../lib/sponsors.js'
 
 const hasSponsors = sponsors().length > 0
 ---
@@ -15,11 +16,11 @@ const hasSponsors = sponsors().length > 0
     who lands here.
   </p>
 
-  <SponsorWall cap={11} />
+  <SponsorWall cap={8} compact />
 
   {hasSponsors && (
     <div class="sponsor-actions">
-      <a class="btn primary" href={SPONSOR_URL} rel="noopener">Become a sponsor</a>
+      <a class="btn primary" href="/sponsors/">Become a sponsor</a>
     </div>
   )}
 </section>

--- a/apps/website/src/components/Sponsors.astro
+++ b/apps/website/src/components/Sponsors.astro
@@ -1,21 +1,15 @@
 ---
-// The homepage sponsor wall. Three states, all handled here:
-//   0 sponsors  — ghost slots that sell the spot itself
-//   a few       — real logos plus one dashed "your logo" slot as the invite
-//   too many    — tiers are capped and the rest roll up into "+N more →",
-//                 with the full wall living at /sponsors
-import { SPONSOR_URL, byTier, activeSponsors } from '../lib/sponsors.js'
+// The homepage sponsor wall — one flat list, no tiers, no prices. Empty, it
+// sells the spot itself with ghost slots; populated, it's a simple row of
+// sponsors plus a dashed "your logo" slot as the standing invite. Overflow
+// past the cap rolls up into "+N more →" pointing at /sponsors.
+import { SPONSOR_URL, sponsors } from '../lib/sponsors.js'
 
-const gold = byTier('gold')
-const silver = byTier('silver')
-const backers = byTier('backer')
-
-const SILVER_CAP = 8
-const BACKER_CAP = 14
-const silverShown = silver.slice(0, SILVER_CAP)
-const backersShown = backers.slice(0, BACKER_CAP)
-const overflow = (silver.length - silverShown.length) + (backers.length - backersShown.length)
-const empty = activeSponsors().length === 0
+const all = sponsors()
+const CAP = 11 // with the invite slot that's two tidy rows at desktop width
+const shown = all.slice(0, CAP)
+const overflow = all.length - shown.length
+const empty = all.length === 0
 
 // The empty wall: six ghost slots fading out to the right, so the space reads
 // as "waiting for logos", not "broken".
@@ -47,48 +41,27 @@ const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
     </div>
   ) : (
     <div class="wall">
-      {gold.length > 0 && (
-        <div class="row gold-row">
-          {gold.map((s) => (
-            <a class="chip gold" href={s.url} rel="noopener sponsored" title={s.name}>
-              {s.logo
-                ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
-                : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
-            </a>
-          ))}
-        </div>
-      )}
-      {silverShown.length > 0 && (
-        <div class="row silver-row">
-          {silverShown.map((s) => (
-            <a class="chip silver" href={s.url} rel="noopener sponsored" title={s.name}>
-              {s.logo
-                ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
-                : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
-            </a>
-          ))}
-          <a class="slot your-slot small" href={SPONSOR_URL} rel="noopener">
-            <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
-            Your logo
+      <div class="row">
+        {shown.map((s) => (
+          <a class="chip" href={s.url} rel="noopener sponsored" title={s.name}>
+            {s.logo
+              ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
+              : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
           </a>
-        </div>
-      )}
-      {backersShown.length > 0 && (
-        <p class="backers">
-          {backersShown.map((s, i) => (
-            <><a href={s.url} rel="noopener sponsored">{s.avatar && <img class="mini-avatar" src={s.avatar} alt="" loading="lazy" />}{s.name}</a>{i < backersShown.length - 1 ? ', ' : ''}</>
-          ))}
-        </p>
-      )}
+        ))}
+        <a class="slot your-slot small" href={SPONSOR_URL} rel="noopener">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+          Your logo
+        </a>
+      </div>
       {overflow > 0 && (
-        <p class="more"><a href="/sponsors/">+ {overflow} more sponsor{overflow === 1 ? '' : 's'} →</a></p>
+        <p class="more"><a href={SPONSOR_URL} rel="noopener">+ {overflow} more sponsor{overflow === 1 ? '' : 's'} on GitHub →</a></p>
       )}
     </div>
   )}
 
   <div class="sponsor-actions">
     <a class="btn primary" href={SPONSOR_URL} rel="noopener">Become a sponsor</a>
-    <a class="btn" href="/sponsors/">See the tiers</a>
   </div>
 </section>
 
@@ -131,11 +104,11 @@ const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
   }
 
   .row { display: flex; flex-wrap: wrap; gap: 12px; align-items: stretch; }
-  .row + .row, .row + .backers, .backers + .more { margin-top: 14px; }
   .chip {
-    display: flex; align-items: center; justify-content: center;
+    display: flex; align-items: center; justify-content: center; gap: 9px;
+    height: 60px; padding: 0 20px;
     border: 1px solid var(--line); border-radius: 12px; background: #fff;
-    padding: 0 22px; text-decoration: none;
+    text-decoration: none;
     transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
   }
   .chip:hover {
@@ -143,23 +116,11 @@ const ghosts = [1, 0.72, 0.52, 0.36, 0.24, 0.15]
     border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
     box-shadow: 0 12px 26px -18px rgba(28, 27, 24, 0.5);
   }
-  .chip.gold { height: 84px; min-width: 200px; gap: 12px; }
-  .chip.silver { height: 60px; min-width: 150px; gap: 9px; }
-  .chip .logo { max-height: 60%; max-width: 170px; object-fit: contain; display: block; }
-  .chip.silver .logo { max-width: 130px; }
-  .chip .avatar { border-radius: 50%; display: block; }
-  .chip.gold .avatar { width: 40px; height: 40px; }
-  .chip.silver .avatar { width: 28px; height: 28px; }
-  .chip-name { font-weight: 700; font-size: 16px; color: var(--ink); letter-spacing: -0.01em; }
-  .chip.silver .chip-name { font-size: 14.5px; }
-  .mini-avatar {
-    width: 18px; height: 18px; border-radius: 50%;
-    vertical-align: -4px; margin-right: 5px; display: inline-block;
-  }
-  .slot.small { height: 60px; min-width: 150px; flex: none; padding: 0 18px; }
+  .chip .logo { max-height: 34px; max-width: 140px; object-fit: contain; display: block; }
+  .chip .avatar { width: 28px; height: 28px; border-radius: 50%; display: block; }
+  .chip-name { font-weight: 700; font-size: 14.5px; color: var(--ink); letter-spacing: -0.01em; }
+  .slot.small { height: 60px; flex: none; padding: 0 18px; }
 
-  .backers { margin: 14px 0 0; color: var(--ink-soft); font-size: 14.5px; line-height: 1.9; }
-  .backers a { color: inherit; font-weight: 600; }
   .more { margin: 12px 0 0; font-size: 14px; }
 
   .sponsor-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 22px; }

--- a/apps/website/src/components/Sponsors.astro
+++ b/apps/website/src/components/Sponsors.astro
@@ -27,15 +27,16 @@ const hasSponsors = sponsors().length > 0
 
 <style>
   /* index.astro's section rhythm is scoped to that file — restate it here.
-     The block centers on the wall's axis, like the support card above it. */
-  .sponsors { margin-top: 96px; text-align: center; }
+     Heading and lede stay left, like every other section; only the wall
+     card centers its own contents. */
+  .sponsors { margin-top: 96px; }
   h2 { font-size: clamp(26px, 4vw, 34px); line-height: 1.2; margin: 0 0 16px; letter-spacing: -0.01em; }
   .section-lede {
-    color: var(--ink-soft); max-width: 56ch; margin: 0 auto 26px;
+    color: var(--ink-soft); max-width: 62ch; margin: 0 0 26px;
     text-wrap: pretty;
   }
 
-  .sponsor-actions { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; margin-top: 22px; }
+  .sponsor-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 22px; }
   .btn {
     display: inline-block; padding: 11px 22px; border-radius: 999px; font-weight: 600;
     border: 1.5px solid var(--ink); color: var(--ink); font-size: 15.5px;

--- a/apps/website/src/consts.js
+++ b/apps/website/src/consts.js
@@ -2,6 +2,6 @@
 // and app.tryquickdraw.com resolves, point APP_URL there.
 export const SITE_URL = 'https://tryquickdraw.com'
 export const APP_URL = 'https://app.tryquickdraw.com'
-export const GITHUB_URL = 'https://github.com/nmndwivedi/quickdraw'
+export const GITHUB_URL = 'https://github.com/quickdrawjs/quickdraw'
 export const SITE_NAME = 'Quickdraw'
 export const SITE_TAGLINE = 'The MIT-licensed infinite-canvas whiteboard SDK'

--- a/apps/website/src/layouts/Base.astro
+++ b/apps/website/src/layouts/Base.astro
@@ -66,6 +66,7 @@ const canonical = new URL(Astro.url.pathname, SITE_URL).href
         <a href={`${GITHUB_URL}/issues`} rel="noopener">Issues</a>
         <a href={`${GITHUB_URL}/discussions`} rel="noopener">Discussions</a>
         <a href={`${GITHUB_URL}/blob/main/CHANGELOG.md`} rel="noopener">Changelog</a>
+        <a href="/sponsors/">Sponsors</a>
       </div>
       <div>
         <strong>Packages</strong>

--- a/apps/website/src/lib/liveStars.js
+++ b/apps/website/src/lib/liveStars.js
@@ -7,7 +7,7 @@
 //
 // Both fail soft — the page already shipped with build-time values baked in.
 
-const REPO = 'nmndwivedi/quickdraw'
+const REPO = 'quickdrawjs/quickdraw'
 const REPO_API = `https://api.github.com/repos/${REPO}`
 const SNAPSHOT = `https://raw.githubusercontent.com/${REPO}/main/docs/star-history.json`
 const COUNT_KEY = 'qd-star-count'

--- a/apps/website/src/lib/sponsors.js
+++ b/apps/website/src/lib/sponsors.js
@@ -1,0 +1,45 @@
+// Sponsorship config — the single source of truth for tiers and the wall.
+// Payments run through GitHub Sponsors; if the platform ever changes, this
+// URL is the only thing to touch.
+export const SPONSOR_URL = 'https://github.com/sponsors/nmndwivedi'
+
+// Highest tier first — every list on the site renders in this order.
+export const TIERS = [
+  {
+    id: 'gold',
+    name: 'Gold',
+    amount: '$100/mo',
+    hue: '#d97706',
+    perks: ['Large logo on the homepage and sponsors page', 'Logo in the README', 'Priority on bug reports'],
+  },
+  {
+    id: 'silver',
+    name: 'Silver',
+    amount: '$25/mo',
+    hue: '#64748b',
+    perks: ['Logo on the homepage and sponsors page', 'Name in the README'],
+  },
+  {
+    id: 'backer',
+    name: 'Backer',
+    amount: '$5/mo',
+    hue: '#2f6fed',
+    perks: ['Name on the sponsors page', 'Our sincere gratitude, forever'],
+  },
+]
+
+// The sponsor wall. After sponsoring, add yourself here via PR (or open an
+// issue and we'll do it): { name, url, tier, logo?, since?, past? }
+//   name  — company or person
+//   url   — where the logo/name links
+//   tier  — 'gold' | 'silver' | 'backer'
+//   logo  — optional path under /public/sponsors/ (SVG with transparent
+//           background preferred; falls back to a text chip without one)
+//   since — 'YYYY-MM', shown on the sponsors page
+//   past  — true moves the entry to the "past sponsors" list; we never
+//           silently delete anyone who supported the project
+export const SPONSORS = []
+
+export const activeSponsors = () => SPONSORS.filter((s) => !s.past)
+export const pastSponsors = () => SPONSORS.filter((s) => s.past)
+export const byTier = (tierId) => activeSponsors().filter((s) => s.tier === tierId)

--- a/apps/website/src/lib/sponsors.js
+++ b/apps/website/src/lib/sponsors.js
@@ -1,45 +1,88 @@
-// Sponsorship config — the single source of truth for tiers and the wall.
-// Payments run through GitHub Sponsors; if the platform ever changes, this
-// URL is the only thing to touch.
+// Sponsorship config + the sponsor wall's data source.
+//
+// The wall feeds itself: .github/workflows/sponsors.yml refreshes
+// docs/sponsors.json from the GitHub Sponsors API daily, and this module
+// reads that snapshot at build time — new sponsors appear automatically with
+// their GitHub avatar, lapsed ones roll off. Nothing here lists prices; the
+// tiers and amounts live on the GitHub Sponsors page itself.
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
 export const SPONSOR_URL = 'https://github.com/sponsors/quickdrawjs'
 
-// Highest tier first — every list on the site renders in this order.
+// Placement levels, highest first. `min` is the monthly amount (in dollars,
+// from the API) that reaches the level — used only to sort sponsors into
+// rows, never rendered.
 export const TIERS = [
   {
     id: 'gold',
     name: 'Gold',
-    amount: '$100/mo',
+    min: 100,
     hue: '#d97706',
     perks: ['Large logo on the homepage and sponsors page', 'Logo in the README', 'Priority on bug reports'],
   },
   {
     id: 'silver',
     name: 'Silver',
-    amount: '$25/mo',
+    min: 25,
     hue: '#64748b',
     perks: ['Logo on the homepage and sponsors page', 'Name in the README'],
   },
   {
     id: 'backer',
     name: 'Backer',
-    amount: '$5/mo',
+    min: 0,
     hue: '#2f6fed',
     perks: ['Name on the sponsors page', 'Our sincere gratitude, forever'],
   },
 ]
 
-// The sponsor wall. After sponsoring, add yourself here via PR (or open an
-// issue and we'll do it): { name, url, tier, logo?, since?, past? }
-//   name  — company or person
-//   url   — where the logo/name links
-//   tier  — 'gold' | 'silver' | 'backer'
-//   logo  — optional path under /public/sponsors/ (SVG with transparent
-//           background preferred; falls back to a text chip without one)
-//   since — 'YYYY-MM', shown on the sponsors page
-//   past  — true moves the entry to the "past sponsors" list; we never
-//           silently delete anyone who supported the project
-export const SPONSORS = []
+// Hand overrides for auto-pulled sponsors, keyed by GitHub login — e.g. a
+// Gold sponsor who sends a proper SVG instead of their avatar:
+//   'acme-inc': { logo: '/sponsors/acme.svg', url: 'https://acme.com' }
+export const OVERRIDES = {}
 
-export const activeSponsors = () => SPONSORS.filter((s) => !s.past)
-export const pastSponsors = () => SPONSORS.filter((s) => s.past)
+// Sponsors who didn't come through GitHub (one-off donations, in-kind
+// support): { name, url, tier, logo?, since?, past? }. `past: true` moves an
+// entry to the thanks list — nobody who supported the project gets deleted.
+export const EXTRA_SPONSORS = []
+
+const EMPTY = { generatedAt: null, sponsors: [] }
+
+function readSnapshot() {
+  // Resolved from this file so it doesn't matter where the build is invoked.
+  const path = fileURLToPath(new URL('../../../../docs/sponsors.json', import.meta.url))
+  try {
+    const data = JSON.parse(readFileSync(path, 'utf8'))
+    return { generatedAt: data.generatedAt ?? null, sponsors: Array.isArray(data.sponsors) ? data.sponsors : [] }
+  } catch {
+    // No snapshot yet (fresh clone, or the workflow hasn't run) — the wall
+    // just shows its empty state.
+    return EMPTY
+  }
+}
+
+const tierFor = (monthly) =>
+  (TIERS.find((t) => (monthly ?? 0) >= t.min) ?? TIERS[TIERS.length - 1]).id
+
+// GitHub-pulled sponsors normalized to the shape the pages render, with any
+// hand overrides applied. Avatars stand in for logos until a sponsor sends
+// a real one via OVERRIDES.
+function autoSponsors() {
+  return readSnapshot().sponsors.map((s) => ({
+    name: s.name || s.login,
+    url: s.url || `https://github.com/${s.login}`,
+    tier: tierFor(s.monthly),
+    logo: null,
+    avatar: s.avatar,
+    since: s.since,
+    ...OVERRIDES[s.login],
+  }))
+}
+
+export const activeSponsors = () => [
+  ...autoSponsors(),
+  ...EXTRA_SPONSORS.filter((s) => !s.past),
+]
+export const pastSponsors = () => EXTRA_SPONSORS.filter((s) => s.past)
 export const byTier = (tierId) => activeSponsors().filter((s) => s.tier === tierId)

--- a/apps/website/src/lib/sponsors.js
+++ b/apps/website/src/lib/sponsors.js
@@ -1,88 +1,41 @@
-// Sponsorship config + the sponsor wall's data source.
+// The sponsor wall's data source — deliberately simple: no tiers, no prices.
 //
 // The wall feeds itself: .github/workflows/sponsors.yml refreshes
 // docs/sponsors.json from the GitHub Sponsors API daily, and this module
-// reads that snapshot at build time — new sponsors appear automatically with
-// their GitHub avatar, lapsed ones roll off. Nothing here lists prices; the
-// tiers and amounts live on the GitHub Sponsors page itself.
+// reads that snapshot at build time. New sponsors appear automatically with
+// their GitHub avatar and name; lapsed ones roll off.
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 export const SPONSOR_URL = 'https://github.com/sponsors/quickdrawjs'
 
-// Placement levels, highest first. `min` is the monthly amount (in dollars,
-// from the API) that reaches the level — used only to sort sponsors into
-// rows, never rendered.
-export const TIERS = [
-  {
-    id: 'gold',
-    name: 'Gold',
-    min: 100,
-    hue: '#d97706',
-    perks: ['Large logo on the homepage and sponsors page', 'Logo in the README', 'Priority on bug reports'],
-  },
-  {
-    id: 'silver',
-    name: 'Silver',
-    min: 25,
-    hue: '#64748b',
-    perks: ['Logo on the homepage and sponsors page', 'Name in the README'],
-  },
-  {
-    id: 'backer',
-    name: 'Backer',
-    min: 0,
-    hue: '#2f6fed',
-    perks: ['Name on the sponsors page', 'Our sincere gratitude, forever'],
-  },
-]
-
-// Hand overrides for auto-pulled sponsors, keyed by GitHub login — e.g. a
-// Gold sponsor who sends a proper SVG instead of their avatar:
-//   'acme-inc': { logo: '/sponsors/acme.svg', url: 'https://acme.com' }
+// Hand overrides keyed by GitHub login — e.g. a sponsor who sends a proper
+// SVG instead of their avatar: 'acme': { logo: '/sponsors/acme.svg' }
 export const OVERRIDES = {}
-
-// Sponsors who didn't come through GitHub (one-off donations, in-kind
-// support): { name, url, tier, logo?, since?, past? }. `past: true` moves an
-// entry to the thanks list — nobody who supported the project gets deleted.
-export const EXTRA_SPONSORS = []
-
-const EMPTY = { generatedAt: null, sponsors: [] }
 
 function readSnapshot() {
   // Resolved from this file so it doesn't matter where the build is invoked.
   const path = fileURLToPath(new URL('../../../../docs/sponsors.json', import.meta.url))
   try {
     const data = JSON.parse(readFileSync(path, 'utf8'))
-    return { generatedAt: data.generatedAt ?? null, sponsors: Array.isArray(data.sponsors) ? data.sponsors : [] }
+    return Array.isArray(data.sponsors) ? data.sponsors : []
   } catch {
     // No snapshot yet (fresh clone, or the workflow hasn't run) — the wall
     // just shows its empty state.
-    return EMPTY
+    return []
   }
 }
 
-const tierFor = (monthly) =>
-  (TIERS.find((t) => (monthly ?? 0) >= t.min) ?? TIERS[TIERS.length - 1]).id
-
-// GitHub-pulled sponsors normalized to the shape the pages render, with any
-// hand overrides applied. Avatars stand in for logos until a sponsor sends
-// a real one via OVERRIDES.
-function autoSponsors() {
-  return readSnapshot().sponsors.map((s) => ({
-    name: s.name || s.login,
-    url: s.url || `https://github.com/${s.login}`,
-    tier: tierFor(s.monthly),
-    logo: null,
-    avatar: s.avatar,
-    since: s.since,
-    ...OVERRIDES[s.login],
-  }))
+// One flat list, most generous first so bigger supporters sit up front.
+export function sponsors() {
+  return readSnapshot()
+    .slice()
+    .sort((a, b) => (b.monthly ?? 0) - (a.monthly ?? 0) || (a.since ?? '').localeCompare(b.since ?? ''))
+    .map((s) => ({
+      name: s.name || s.login,
+      url: s.url || `https://github.com/${s.login}`,
+      avatar: s.avatar,
+      logo: null,
+      ...OVERRIDES[s.login],
+    }))
 }
-
-export const activeSponsors = () => [
-  ...autoSponsors(),
-  ...EXTRA_SPONSORS.filter((s) => !s.past),
-]
-export const pastSponsors = () => EXTRA_SPONSORS.filter((s) => s.past)
-export const byTier = (tierId) => activeSponsors().filter((s) => s.tier === tierId)

--- a/apps/website/src/lib/sponsors.js
+++ b/apps/website/src/lib/sponsors.js
@@ -1,7 +1,7 @@
 // Sponsorship config — the single source of truth for tiers and the wall.
 // Payments run through GitHub Sponsors; if the platform ever changes, this
 // URL is the only thing to touch.
-export const SPONSOR_URL = 'https://github.com/sponsors/nmndwivedi'
+export const SPONSOR_URL = 'https://github.com/sponsors/quickdrawjs'
 
 // Highest tier first — every list on the site renders in this order.
 export const TIERS = [

--- a/apps/website/src/pages/blog/add-whiteboard-to-react-app.md
+++ b/apps/website/src/pages/blog/add-whiteboard-to-react-app.md
@@ -124,4 +124,4 @@ deeper story — why diffs beat operational transforms for this use case — rea
 
 - [Documentation](/docs/) — persistence, headless mode, React Native
 - [Try the hosted app](https://app.tryquickdraw.com) — the same SDK, deployed
-- [GitHub](https://github.com/nmndwivedi/quickdraw) — MIT, open to contributions
+- [GitHub](https://github.com/quickdrawjs/quickdraw) — MIT, open to contributions

--- a/apps/website/src/pages/blog/free-online-whiteboard-no-signup.md
+++ b/apps/website/src/pages/blog/free-online-whiteboard-no-signup.md
@@ -53,7 +53,7 @@ npm install @quickdrawjs/react
 ```
 
 The [docs](/docs/) take it from there, and the whole thing is
-[open source](https://github.com/nmndwivedi/quickdraw).
+[open source](https://github.com/quickdrawjs/quickdraw).
 
 ## Keyboard shortcuts worth knowing
 

--- a/apps/website/src/pages/blog/infinite-canvas-camera-math.md
+++ b/apps/website/src/pages/blog/infinite-canvas-camera-math.md
@@ -117,7 +117,7 @@ working when zoomed" bugs.
 ## See it running
 
 All of this is implemented in
-[Quickdraw's editor](https://github.com/nmndwivedi/quickdraw), MIT-licensed
+[Quickdraw's editor](https://github.com/quickdrawjs/quickdraw), MIT-licensed
 — `editor.js` has the camera, `shapes.js` the hit-testing. If you'd rather
 not build the rest of the whiteboard (undo, selection, styles, export...),
 that's the [point of the SDK](/docs/):

--- a/apps/website/src/pages/blog/introducing-quickdraw.md
+++ b/apps/website/src/pages/blog/introducing-quickdraw.md
@@ -137,18 +137,18 @@ the transport), no layers, no frames, and no rich text. Excalidraw and
 tldraw have years of production hardening and far bigger communities than a
 project released today.
 
-The [roadmap is public](https://github.com/nmndwivedi/quickdraw/issues/1).
+The [roadmap is public](https://github.com/quickdrawjs/quickdraw/issues/1).
 If the missing feature that sent you back to a paid SDK is on it — or
 isn't — say so there.
 
 ## Try it
 
 - **Live app, no signup:** [app.tryquickdraw.com](https://app.tryquickdraw.com)
-- **Repo:** [github.com/nmndwivedi/quickdraw](https://github.com/nmndwivedi/quickdraw)
+- **Repo:** [github.com/quickdrawjs/quickdraw](https://github.com/quickdrawjs/quickdraw)
 - **Docs:** [tryquickdraw.com](https://tryquickdraw.com)
 
 If you've embedded a whiteboard in production before, I'd genuinely like to
 know what you hit that I should handle better —
-[open an issue](https://github.com/nmndwivedi/quickdraw/issues) or start a
-[discussion](https://github.com/nmndwivedi/quickdraw/discussions). And if
+[open an issue](https://github.com/quickdrawjs/quickdraw/issues) or start a
+[discussion](https://github.com/quickdrawjs/quickdraw/discussions). And if
 it's useful to you, a star helps other people find it.

--- a/apps/website/src/pages/blog/open-source-tldraw-alternatives.md
+++ b/apps/website/src/pages/blog/open-source-tldraw-alternatives.md
@@ -108,7 +108,7 @@ not a knock on either project.
 - **You only need ink and enjoy building canvases:** perfect-freehand.
 - **The license cost is fine for your business:** tldraw remains excellent.
 
-Quickdraw is [open to contributions](https://github.com/nmndwivedi/quickdraw).
+Quickdraw is [open to contributions](https://github.com/quickdrawjs/quickdraw).
 If the missing feature that sent you back to a paid SDK is on the
-[roadmap](https://github.com/nmndwivedi/quickdraw/issues/1), tell us — or
+[roadmap](https://github.com/quickdrawjs/quickdraw/issues/1), tell us — or
 build it with us.

--- a/apps/website/src/pages/blog/react-native-whiteboard-drawing.md
+++ b/apps/website/src/pages/blog/react-native-whiteboard-drawing.md
@@ -96,4 +96,4 @@ renderer (`@shopify/react-native-skia`) is the right tool — at the cost of
 building the whiteboard layer yourself. For a document-style whiteboard,
 notes app, or annotation feature, the WebView architecture is what ships.
 
-*Quickdraw is MIT-licensed and [open to contributions](https://github.com/nmndwivedi/quickdraw).*
+*Quickdraw is MIT-licensed and [open to contributions](https://github.com/quickdrawjs/quickdraw).*

--- a/apps/website/src/pages/blog/real-time-whiteboard-sync-json-diffs.md
+++ b/apps/website/src/pages/blog/real-time-whiteboard-sync-json-diffs.md
@@ -102,8 +102,8 @@ audit trail of a board, stroke by stroke.
 
 ## Try it
 
-The [roadmap](https://github.com/nmndwivedi/quickdraw/issues/1) includes a
+The [roadmap](https://github.com/quickdrawjs/quickdraw/issues/1) includes a
 runnable two-browser sync example, and
-[issue #4](https://github.com/nmndwivedi/quickdraw/issues/4) is open if you'd
+[issue #4](https://github.com/quickdrawjs/quickdraw/issues/4) is open if you'd
 like to build it with us. Quickdraw is MIT-licensed:
-[github.com/nmndwivedi/quickdraw](https://github.com/nmndwivedi/quickdraw).
+[github.com/quickdrawjs/quickdraw](https://github.com/quickdrawjs/quickdraw).

--- a/apps/website/src/pages/blog/tldraw-vs-excalidraw-vs-quickdraw.md
+++ b/apps/website/src/pages/blog/tldraw-vs-excalidraw-vs-quickdraw.md
@@ -71,7 +71,7 @@ The flip side of weight is capability: tldraw's shape and tool plugin
 system is the richest of the three, and Excalidraw ships years of
 accumulated features (component libraries, rich export options,
 localization). Quickdraw ships a complete but focused whiteboard; its
-[roadmap](https://github.com/nmndwivedi/quickdraw/issues/1) is public.
+[roadmap](https://github.com/quickdrawjs/quickdraw/issues/1) is public.
 
 ## Look and feel
 
@@ -97,7 +97,7 @@ board switches between light and dark themes.
 Be honest about this one: tldraw and Excalidraw have big communities, years
 of production hardening, and large test surfaces. Quickdraw is new —
 smaller API surface, ~120 tests, one engine shared across three packages,
-and an open [issue tracker](https://github.com/nmndwivedi/quickdraw/issues)
+and an open [issue tracker](https://github.com/quickdrawjs/quickdraw/issues)
 you can actually influence. Young projects earn trust in public; that's why
 everything is MIT on GitHub.
 
@@ -113,4 +113,4 @@ everything is MIT on GitHub.
 
 Corrections welcome — licensing and features change, and we'd rather this
 page be right than flattering:
-[open an issue](https://github.com/nmndwivedi/quickdraw/issues).
+[open an issue](https://github.com/quickdrawjs/quickdraw/issues).

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -3,6 +3,7 @@ import Base from '../layouts/Base.astro'
 import CompareTable from '../components/CompareTable.astro'
 import StarButton from '../components/StarButton.astro'
 import StarHistory from '../components/StarHistory.astro'
+import Sponsors from '../components/Sponsors.astro'
 import { readStarHistory } from '../lib/starData.js'
 import { APP_URL, GITHUB_URL, SITE_URL } from '../consts.js'
 
@@ -285,6 +286,8 @@ createQuickdraw({
         </div>
       </div>
     </section>
+
+    <Sponsors />
 
     <section class="faq" id="faq">
       <h2>Questions people ask</h2>

--- a/apps/website/src/pages/sponsors.astro
+++ b/apps/website/src/pages/sponsors.astro
@@ -1,0 +1,236 @@
+---
+// The full sponsor wall — uncapped, unlike the homepage section. This page
+// always exists so "too many sponsors for the homepage" is never a problem:
+// the homepage rolls overflow up into a "+N more" link that lands here.
+import Base from '../layouts/Base.astro'
+import { GITHUB_URL } from '../consts.js'
+import { SPONSOR_URL, TIERS, byTier, pastSponsors, activeSponsors } from '../lib/sponsors.js'
+
+const past = pastSponsors()
+const empty = activeSponsors().length === 0
+
+const steps = [
+  {
+    title: 'Pick a tier',
+    body: 'Sponsorship runs through GitHub Sponsors — a standard GitHub checkout, monthly or one-time, with receipts and invoices handled for you.',
+  },
+  {
+    title: 'Send your logo',
+    body: 'Open a PR adding yourself to sponsors.js (an SVG with a transparent background works best), or just open an issue and we’ll do it for you.',
+  },
+  {
+    title: 'You’re on the wall',
+    body: 'Your logo ships with the next deploy — on this page, the homepage, and (Gold and Silver) the README on GitHub and npm.',
+  },
+]
+---
+<Base
+  title="Sponsor Quickdraw — keep the whiteboard SDK MIT-licensed"
+  description="Sponsor Quickdraw and get your logo in front of the developers choosing a whiteboard SDK. Tiers from $5/mo, payments via GitHub Sponsors."
+>
+  <main>
+    <section class="hero">
+      <h1>Sponsor <span class="qd">Quickdraw</span></h1>
+      <p class="lede">
+        Quickdraw is MIT-licensed and free for commercial use, forever. There is
+        no paid tier waiting behind a curtain — sponsorship is the entire
+        business model. In return, your logo sits in front of every developer
+        who is actively choosing a whiteboard SDK.
+      </p>
+      <div class="actions">
+        <a class="btn primary" href={SPONSOR_URL} rel="noopener">Become a sponsor</a>
+        <a class="btn" href={GITHUB_URL} rel="noopener">Star the repo instead</a>
+      </div>
+    </section>
+
+    <section class="tiers">
+      <h2>Tiers</h2>
+      <div class="tier-grid">
+        {TIERS.map((t) => (
+          <div class="tier" style={`--c: ${t.hue}`}>
+            <div class="tier-head">
+              <h3>{t.name}</h3>
+              <span class="amount">{t.amount}</span>
+            </div>
+            <ul>
+              {t.perks.map((p) => (
+                <li>
+                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12.5 4.5 4.5L19 7"/></svg>
+                  {p}
+                </li>
+              ))}
+            </ul>
+            <a class="tier-cta" href={SPONSOR_URL} rel="noopener">Sponsor at {t.name} →</a>
+          </div>
+        ))}
+      </div>
+      <p class="fine-print">
+        One-time donations of any size are welcome too. Want something a tier
+        doesn't cover — a support arrangement, a feature bounty?
+        <a href={`${GITHUB_URL}/discussions`} rel="noopener">Start a discussion.</a>
+      </p>
+    </section>
+
+    <section class="wall-section">
+      <h2>The wall</h2>
+      {empty ? (
+        <div class="empty-wall">
+          <svg viewBox="0 0 24 24" width="30" height="30" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21s-7.5-4.6-9.5-9.2C1 8 3.2 4.6 6.8 4.6c2.2 0 3.9 1.2 5.2 3 1.3-1.8 3-3 5.2-3 3.6 0 5.8 3.4 4.3 7.2C19.5 16.4 12 21 12 21Z"/></svg>
+          <p class="empty-title">Nobody's here yet.</p>
+          <p>
+            Which means the first sponsors get the one thing money usually
+            can't buy on a sponsor wall: being first. Founding sponsors stay
+            marked as such for the life of the project.
+          </p>
+          <a class="btn primary" href={SPONSOR_URL} rel="noopener">Claim the first spot</a>
+        </div>
+      ) : (
+        <div class="full-wall">
+          {TIERS.map((t) => {
+            const list = byTier(t.id)
+            return list.length > 0 && (
+              <div class="tier-block">
+                <h3 class="tier-label" style={`--c: ${t.hue}`}>{t.name}</h3>
+                <div class={`row ${t.id}`}>
+                  {list.map((s) => (
+                    <a class={`chip ${t.id}`} href={s.url} rel="noopener sponsored" title={s.since ? `${s.name} — sponsor since ${s.since}` : s.name}>
+                      {s.logo ? <img src={s.logo} alt={s.name} loading="lazy" /> : <span class="chip-name">{s.name}</span>}
+                    </a>
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+      {past.length > 0 && (
+        <p class="past">
+          Past sponsors, with thanks:
+          {past.map((s, i) => (
+            <> <a href={s.url} rel="noopener">{s.name}</a>{i < past.length - 1 ? ',' : ''}</>
+          ))}
+        </p>
+      )}
+    </section>
+
+    <section class="how">
+      <h2>How it works</h2>
+      <ol class="steps">
+        {steps.map((s, i) => (
+          <li>
+            <span class="n">{i + 1}</span>
+            <div>
+              <h3>{s.title}</h3>
+              <p>{s.body}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+      <p class="fine-print">
+        Sponsorship never buys influence over the roadmap or the license —
+        Quickdraw stays MIT either way. Logos link with
+        <code>rel="sponsored"</code>, cancel anytime, and past sponsors are
+        acknowledged here permanently.
+      </p>
+    </section>
+  </main>
+</Base>
+
+<style>
+  main { max-width: var(--max); margin: 0 auto; padding: 0 20px 40px; }
+  section { margin-top: 72px; }
+  h2 { font-size: clamp(24px, 3.6vw, 30px); line-height: 1.2; margin: 0 0 22px; letter-spacing: -0.01em; }
+
+  .hero { margin-top: 56px; max-width: 640px; }
+  h1 { font-size: clamp(32px, 5vw, 46px); line-height: 1.12; margin: 0 0 16px; letter-spacing: -0.02em; }
+  .qd { color: var(--accent); }
+  .lede { font-size: 17px; color: var(--ink-soft); margin: 0 0 26px; text-wrap: pretty; }
+  .actions { display: flex; gap: 12px; flex-wrap: wrap; }
+  .btn {
+    display: inline-block; padding: 11px 22px; border-radius: 999px; font-weight: 600;
+    border: 1.5px solid var(--ink); color: var(--ink); font-size: 15.5px;
+  }
+  .btn:hover { text-decoration: none; background: var(--paper-2); }
+  .btn.primary { background: var(--ink); color: var(--paper); }
+  .btn.primary:hover { background: #000; }
+
+  .tier-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; }
+  .tier {
+    --c: var(--accent);
+    display: flex; flex-direction: column;
+    background: #fff; border: 1px solid var(--line); border-radius: var(--radius);
+    border-top: 3px solid color-mix(in srgb, var(--c) 70%, #fff);
+    padding: 20px 22px;
+  }
+  .tier-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; margin-bottom: 10px; }
+  .tier h3 { margin: 0; font-size: 18px; }
+  .amount { font-weight: 700; font-size: 15px; color: color-mix(in srgb, var(--c) 70%, var(--ink)); font-variant-numeric: tabular-nums; }
+  .tier ul { list-style: none; margin: 0 0 16px; padding: 0; flex: 1; }
+  .tier li {
+    display: flex; gap: 8px; align-items: baseline;
+    color: var(--ink-soft); font-size: 14.5px; line-height: 1.5; padding: 3px 0;
+  }
+  .tier li svg { flex: none; color: color-mix(in srgb, var(--c) 80%, var(--ink)); position: relative; top: 1px; }
+  .tier-cta { font-weight: 600; font-size: 14.5px; }
+
+  .empty-wall {
+    text-align: center; background: #fff; border: 1.5px dashed var(--line);
+    border-radius: var(--radius); padding: 44px 26px;
+  }
+  .empty-wall svg { color: color-mix(in srgb, var(--accent) 70%, var(--ink)); margin-bottom: 8px; }
+  .empty-title { font-weight: 700; font-size: 18px; margin: 0 0 8px; }
+  .empty-wall p { color: var(--ink-soft); max-width: 46ch; margin: 0 auto 20px; text-wrap: pretty; }
+  .empty-wall .empty-title { color: var(--ink); }
+
+  .tier-block + .tier-block { margin-top: 26px; }
+  .tier-label {
+    font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em;
+    color: color-mix(in srgb, var(--c) 65%, var(--ink)); margin: 0 0 10px;
+  }
+  .row { display: flex; flex-wrap: wrap; gap: 12px; }
+  .chip {
+    display: flex; align-items: center; justify-content: center;
+    border: 1px solid var(--line); border-radius: 12px; background: #fff;
+    padding: 0 22px; text-decoration: none;
+    transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
+  }
+  .chip:hover {
+    transform: translateY(-2px); text-decoration: none;
+    border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
+    box-shadow: 0 12px 26px -18px rgba(28, 27, 24, 0.5);
+  }
+  .chip.gold { height: 92px; min-width: 220px; }
+  .chip.silver { height: 64px; min-width: 160px; }
+  .chip.backer { height: 44px; min-width: 0; padding: 0 16px; }
+  .chip img { max-height: 60%; max-width: 180px; object-fit: contain; display: block; }
+  .chip-name { font-weight: 700; color: var(--ink); letter-spacing: -0.01em; }
+  .chip.gold .chip-name { font-size: 17px; }
+  .chip.silver .chip-name { font-size: 15px; }
+  .chip.backer .chip-name { font-size: 13.5px; font-weight: 600; }
+  .past { margin-top: 26px; color: var(--ink-soft); font-size: 14px; }
+
+  .steps { list-style: none; margin: 0; padding: 0; display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; }
+  .steps li {
+    display: flex; gap: 14px; align-items: flex-start;
+    background: #fff; border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 18px 20px;
+  }
+  .steps .n {
+    flex: none; width: 28px; height: 28px; border-radius: 999px;
+    display: flex; align-items: center; justify-content: center;
+    background: var(--ink); color: var(--paper); font-weight: 700; font-size: 14px;
+  }
+  .steps h3 { margin: 2px 0 6px; font-size: 16px; }
+  .steps p { margin: 0; color: var(--ink-soft); font-size: 14.5px; line-height: 1.55; }
+
+  .fine-print { font-size: 13px; color: var(--ink-soft); margin-top: 14px; }
+
+  @media (max-width: 460px) {
+    .actions { display: grid; grid-template-columns: 1fr; gap: 10px; }
+    .btn { text-align: center; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .chip { transition: none; }
+    .chip:hover { transform: none; }
+  }
+</style>

--- a/apps/website/src/pages/sponsors.astro
+++ b/apps/website/src/pages/sponsors.astro
@@ -61,8 +61,7 @@ const empty = all.length === 0
         Sponsors</a> daily — sponsor there and you appear here automatically,
         name and avatar, no PR needed. Prefer a proper logo? Send an SVG via
         <a href={`${GITHUB_URL}/issues`} rel="noopener">issue</a> and it
-        replaces the avatar. Sponsorship never buys influence over the roadmap
-        or the license — Quickdraw stays MIT either way.
+        replaces the avatar.
       </p>
     </section>
   </main>

--- a/apps/website/src/pages/sponsors.astro
+++ b/apps/website/src/pages/sponsors.astro
@@ -1,32 +1,17 @@
 ---
-// The full sponsor wall — uncapped, unlike the homepage section. This page
-// always exists so "too many sponsors for the homepage" is never a problem:
-// the homepage rolls overflow up into a "+N more" link that lands here.
+// The sponsors page — a simple invite that points at GitHub Sponsors. No
+// tiers, no prices: the wall is one flat list that syncs from the GitHub
+// Sponsors API daily (see .github/workflows/sponsors.yml).
 import Base from '../layouts/Base.astro'
 import { GITHUB_URL } from '../consts.js'
-import { SPONSOR_URL, TIERS, byTier, pastSponsors, activeSponsors } from '../lib/sponsors.js'
+import { SPONSOR_URL, sponsors } from '../lib/sponsors.js'
 
-const past = pastSponsors()
-const empty = activeSponsors().length === 0
-
-const steps = [
-  {
-    title: 'Sponsor on GitHub',
-    body: 'Sponsorship runs through GitHub Sponsors — a standard GitHub checkout, monthly or one-time, with receipts and invoices handled for you.',
-  },
-  {
-    title: 'You appear automatically',
-    body: 'The wall syncs with GitHub Sponsors daily: your name and avatar show up here and on the homepage within a day, no PR needed.',
-  },
-  {
-    title: 'Optional: a real logo',
-    body: 'Gold and Silver sponsors can swap the avatar for a proper logo — send an SVG via issue or PR and it replaces the avatar everywhere, README included.',
-  },
-]
+const all = sponsors()
+const empty = all.length === 0
 ---
 <Base
   title="Sponsor Quickdraw — keep the whiteboard SDK MIT-licensed"
-  description="Sponsor Quickdraw and get your logo in front of the developers choosing a whiteboard SDK. Tiers from $5/mo, payments via GitHub Sponsors."
+  description="Sponsor Quickdraw and get your logo in front of the developers choosing a whiteboard SDK. Payments via GitHub Sponsors."
 >
   <main>
     <section class="hero">
@@ -38,36 +23,9 @@ const steps = [
         who is actively choosing a whiteboard SDK.
       </p>
       <div class="actions">
-        <a class="btn primary" href={SPONSOR_URL} rel="noopener">Become a sponsor</a>
+        <a class="btn primary" href={SPONSOR_URL} rel="noopener">Sponsor on GitHub</a>
         <a class="btn" href={GITHUB_URL} rel="noopener">Star the repo instead</a>
       </div>
-    </section>
-
-    <section class="tiers">
-      <h2>Tiers</h2>
-      <div class="tier-grid">
-        {TIERS.map((t) => (
-          <div class="tier" style={`--c: ${t.hue}`}>
-            <div class="tier-head">
-              <h3>{t.name}</h3>
-            </div>
-            <ul>
-              {t.perks.map((p) => (
-                <li>
-                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12.5 4.5 4.5L19 7"/></svg>
-                  {p}
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
-      </div>
-      <p class="fine-print">
-        Amounts and one-time options live on the
-        <a href={SPONSOR_URL} rel="noopener">GitHub Sponsors page</a>. Want
-        something a tier doesn't cover — a support arrangement, a feature
-        bounty? <a href={`${GITHUB_URL}/discussions`} rel="noopener">Start a discussion.</a>
-      </p>
     </section>
 
     <section class="wall-section">
@@ -84,61 +42,34 @@ const steps = [
           <a class="btn primary" href={SPONSOR_URL} rel="noopener">Claim the first spot</a>
         </div>
       ) : (
-        <div class="full-wall">
-          {TIERS.map((t) => {
-            const list = byTier(t.id)
-            return list.length > 0 && (
-              <div class="tier-block">
-                <h3 class="tier-label" style={`--c: ${t.hue}`}>{t.name}</h3>
-                <div class={`row ${t.id}`}>
-                  {list.map((s) => (
-                    <a class={`chip ${t.id}`} href={s.url} rel="noopener sponsored" title={s.since ? `${s.name} — sponsor since ${s.since}` : s.name}>
-                      {s.logo
-                        ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
-                        : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
-                    </a>
-                  ))}
-                </div>
-              </div>
-            )
-          })}
+        <div class="row">
+          {all.map((s) => (
+            <a class="chip" href={s.url} rel="noopener sponsored" title={s.name}>
+              {s.logo
+                ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
+                : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
+            </a>
+          ))}
+          <a class="chip your-slot" href={SPONSOR_URL} rel="noopener">
+            <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+            Your logo
+          </a>
         </div>
       )}
-      {past.length > 0 && (
-        <p class="past">
-          Past sponsors, with thanks:
-          {past.map((s, i) => (
-            <> <a href={s.url} rel="noopener">{s.name}</a>{i < past.length - 1 ? ',' : ''}</>
-          ))}
-        </p>
-      )}
-    </section>
-
-    <section class="how">
-      <h2>How it works</h2>
-      <ol class="steps">
-        {steps.map((s, i) => (
-          <li>
-            <span class="n">{i + 1}</span>
-            <div>
-              <h3>{s.title}</h3>
-              <p>{s.body}</p>
-            </div>
-          </li>
-        ))}
-      </ol>
       <p class="fine-print">
-        Sponsorship never buys influence over the roadmap or the license —
-        Quickdraw stays MIT either way. Logos link with
-        <code>rel="sponsored"</code>, cancel anytime, and past sponsors are
-        acknowledged here permanently.
+        The wall syncs with <a href={SPONSOR_URL} rel="noopener">GitHub
+        Sponsors</a> daily — sponsor there and you appear here automatically,
+        name and avatar, no PR needed. Prefer a proper logo? Send an SVG via
+        <a href={`${GITHUB_URL}/issues`} rel="noopener">issue</a> and it
+        replaces the avatar. Sponsorship never buys influence over the roadmap
+        or the license — Quickdraw stays MIT either way.
       </p>
     </section>
   </main>
 </Base>
 
 <style>
-  main { max-width: var(--max); margin: 0 auto; padding: 0 20px 40px; }
+  main { max-width: var(--max); margin: 0 auto; padding: 0 20px 60px; }
   section { margin-top: 72px; }
   h2 { font-size: clamp(24px, 3.6vw, 30px); line-height: 1.2; margin: 0 0 22px; letter-spacing: -0.01em; }
 
@@ -155,42 +86,20 @@ const steps = [
   .btn.primary { background: var(--ink); color: var(--paper); }
   .btn.primary:hover { background: #000; }
 
-  .tier-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; }
-  .tier {
-    --c: var(--accent);
-    display: flex; flex-direction: column;
-    background: #fff; border: 1px solid var(--line); border-radius: var(--radius);
-    border-top: 3px solid color-mix(in srgb, var(--c) 70%, #fff);
-    padding: 20px 22px;
-  }
-  .tier-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; margin-bottom: 10px; }
-  .tier h3 { margin: 0; font-size: 18px; }
-  .tier ul { list-style: none; margin: 0; padding: 0; flex: 1; }
-  .tier li {
-    display: flex; gap: 8px; align-items: baseline;
-    color: var(--ink-soft); font-size: 14.5px; line-height: 1.5; padding: 3px 0;
-  }
-  .tier li svg { flex: none; color: color-mix(in srgb, var(--c) 80%, var(--ink)); position: relative; top: 1px; }
-
   .empty-wall {
     text-align: center; background: #fff; border: 1.5px dashed var(--line);
     border-radius: var(--radius); padding: 44px 26px;
   }
   .empty-wall svg { color: color-mix(in srgb, var(--accent) 70%, var(--ink)); margin-bottom: 8px; }
-  .empty-title { font-weight: 700; font-size: 18px; margin: 0 0 8px; }
+  .empty-title { font-weight: 700; font-size: 18px; margin: 0 0 8px; color: var(--ink); }
   .empty-wall p { color: var(--ink-soft); max-width: 46ch; margin: 0 auto 20px; text-wrap: pretty; }
-  .empty-wall .empty-title { color: var(--ink); }
 
-  .tier-block + .tier-block { margin-top: 26px; }
-  .tier-label {
-    font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em;
-    color: color-mix(in srgb, var(--c) 65%, var(--ink)); margin: 0 0 10px;
-  }
   .row { display: flex; flex-wrap: wrap; gap: 12px; }
   .chip {
-    display: flex; align-items: center; justify-content: center;
+    display: flex; align-items: center; justify-content: center; gap: 9px;
+    height: 60px; padding: 0 20px;
     border: 1px solid var(--line); border-radius: 12px; background: #fff;
-    padding: 0 22px; text-decoration: none;
+    text-decoration: none;
     transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
   }
   .chip:hover {
@@ -198,36 +107,21 @@ const steps = [
     border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
     box-shadow: 0 12px 26px -18px rgba(28, 27, 24, 0.5);
   }
-  .chip.gold { height: 92px; min-width: 220px; }
-  .chip.silver { height: 64px; min-width: 160px; }
-  .chip.backer { height: 44px; min-width: 0; padding: 0 16px; }
-  .chip { gap: 10px; }
-  .chip .logo { max-height: 60%; max-width: 180px; object-fit: contain; display: block; }
-  .chip .avatar { border-radius: 50%; display: block; }
-  .chip.gold .avatar { width: 44px; height: 44px; }
-  .chip.silver .avatar { width: 30px; height: 30px; }
-  .chip.backer .avatar { width: 22px; height: 22px; }
-  .chip-name { font-weight: 700; color: var(--ink); letter-spacing: -0.01em; }
-  .chip.gold .chip-name { font-size: 17px; }
-  .chip.silver .chip-name { font-size: 15px; }
-  .chip.backer .chip-name { font-size: 13.5px; font-weight: 600; }
-  .past { margin-top: 26px; color: var(--ink-soft); font-size: 14px; }
-
-  .steps { list-style: none; margin: 0; padding: 0; display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; }
-  .steps li {
-    display: flex; gap: 14px; align-items: flex-start;
-    background: #fff; border: 1px solid var(--line); border-radius: var(--radius);
-    padding: 18px 20px;
+  .chip .logo { max-height: 34px; max-width: 140px; object-fit: contain; display: block; }
+  .chip .avatar { width: 28px; height: 28px; border-radius: 50%; display: block; }
+  .chip-name { font-weight: 700; font-size: 14.5px; color: var(--ink); letter-spacing: -0.01em; }
+  .your-slot {
+    border: 1.5px dashed color-mix(in srgb, var(--accent) 45%, transparent);
+    color: color-mix(in srgb, var(--accent) 75%, var(--ink));
+    background: color-mix(in srgb, var(--accent) 4%, transparent);
+    font-weight: 600; font-size: 13.5px;
   }
-  .steps .n {
-    flex: none; width: 28px; height: 28px; border-radius: 999px;
-    display: flex; align-items: center; justify-content: center;
-    background: var(--ink); color: var(--paper); font-weight: 700; font-size: 14px;
+  .your-slot:hover {
+    background: color-mix(in srgb, var(--accent) 9%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 70%, transparent);
   }
-  .steps h3 { margin: 2px 0 6px; font-size: 16px; }
-  .steps p { margin: 0; color: var(--ink-soft); font-size: 14.5px; line-height: 1.55; }
 
-  .fine-print { font-size: 13px; color: var(--ink-soft); margin-top: 14px; }
+  .fine-print { font-size: 13.5px; color: var(--ink-soft); margin-top: 18px; max-width: 72ch; }
 
   @media (max-width: 460px) {
     .actions { display: grid; grid-template-columns: 1fr; gap: 10px; }

--- a/apps/website/src/pages/sponsors.astro
+++ b/apps/website/src/pages/sponsors.astro
@@ -11,16 +11,16 @@ const empty = activeSponsors().length === 0
 
 const steps = [
   {
-    title: 'Pick a tier',
+    title: 'Sponsor on GitHub',
     body: 'Sponsorship runs through GitHub Sponsors — a standard GitHub checkout, monthly or one-time, with receipts and invoices handled for you.',
   },
   {
-    title: 'Send your logo',
-    body: 'Open a PR adding yourself to sponsors.js (an SVG with a transparent background works best), or just open an issue and we’ll do it for you.',
+    title: 'You appear automatically',
+    body: 'The wall syncs with GitHub Sponsors daily: your name and avatar show up here and on the homepage within a day, no PR needed.',
   },
   {
-    title: 'You’re on the wall',
-    body: 'Your logo ships with the next deploy — on this page, the homepage, and (Gold and Silver) the README on GitHub and npm.',
+    title: 'Optional: a real logo',
+    body: 'Gold and Silver sponsors can swap the avatar for a proper logo — send an SVG via issue or PR and it replaces the avatar everywhere, README included.',
   },
 ]
 ---
@@ -50,7 +50,6 @@ const steps = [
           <div class="tier" style={`--c: ${t.hue}`}>
             <div class="tier-head">
               <h3>{t.name}</h3>
-              <span class="amount">{t.amount}</span>
             </div>
             <ul>
               {t.perks.map((p) => (
@@ -60,14 +59,14 @@ const steps = [
                 </li>
               ))}
             </ul>
-            <a class="tier-cta" href={SPONSOR_URL} rel="noopener">Sponsor at {t.name} →</a>
           </div>
         ))}
       </div>
       <p class="fine-print">
-        One-time donations of any size are welcome too. Want something a tier
-        doesn't cover — a support arrangement, a feature bounty?
-        <a href={`${GITHUB_URL}/discussions`} rel="noopener">Start a discussion.</a>
+        Amounts and one-time options live on the
+        <a href={SPONSOR_URL} rel="noopener">GitHub Sponsors page</a>. Want
+        something a tier doesn't cover — a support arrangement, a feature
+        bounty? <a href={`${GITHUB_URL}/discussions`} rel="noopener">Start a discussion.</a>
       </p>
     </section>
 
@@ -94,7 +93,9 @@ const steps = [
                 <div class={`row ${t.id}`}>
                   {list.map((s) => (
                     <a class={`chip ${t.id}`} href={s.url} rel="noopener sponsored" title={s.since ? `${s.name} — sponsor since ${s.since}` : s.name}>
-                      {s.logo ? <img src={s.logo} alt={s.name} loading="lazy" /> : <span class="chip-name">{s.name}</span>}
+                      {s.logo
+                        ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
+                        : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
                     </a>
                   ))}
                 </div>
@@ -164,14 +165,12 @@ const steps = [
   }
   .tier-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; margin-bottom: 10px; }
   .tier h3 { margin: 0; font-size: 18px; }
-  .amount { font-weight: 700; font-size: 15px; color: color-mix(in srgb, var(--c) 70%, var(--ink)); font-variant-numeric: tabular-nums; }
-  .tier ul { list-style: none; margin: 0 0 16px; padding: 0; flex: 1; }
+  .tier ul { list-style: none; margin: 0; padding: 0; flex: 1; }
   .tier li {
     display: flex; gap: 8px; align-items: baseline;
     color: var(--ink-soft); font-size: 14.5px; line-height: 1.5; padding: 3px 0;
   }
   .tier li svg { flex: none; color: color-mix(in srgb, var(--c) 80%, var(--ink)); position: relative; top: 1px; }
-  .tier-cta { font-weight: 600; font-size: 14.5px; }
 
   .empty-wall {
     text-align: center; background: #fff; border: 1.5px dashed var(--line);
@@ -202,7 +201,12 @@ const steps = [
   .chip.gold { height: 92px; min-width: 220px; }
   .chip.silver { height: 64px; min-width: 160px; }
   .chip.backer { height: 44px; min-width: 0; padding: 0 16px; }
-  .chip img { max-height: 60%; max-width: 180px; object-fit: contain; display: block; }
+  .chip { gap: 10px; }
+  .chip .logo { max-height: 60%; max-width: 180px; object-fit: contain; display: block; }
+  .chip .avatar { border-radius: 50%; display: block; }
+  .chip.gold .avatar { width: 44px; height: 44px; }
+  .chip.silver .avatar { width: 30px; height: 30px; }
+  .chip.backer .avatar { width: 22px; height: 22px; }
   .chip-name { font-weight: 700; color: var(--ink); letter-spacing: -0.01em; }
   .chip.gold .chip-name { font-size: 17px; }
   .chip.silver .chip-name { font-size: 15px; }

--- a/apps/website/src/pages/sponsors.astro
+++ b/apps/website/src/pages/sponsors.astro
@@ -40,18 +40,17 @@ import { SPONSOR_URL } from '../lib/sponsors.js'
 </Base>
 
 <style>
-  /* The whole page centers on the wall's axis — it's a pitch page, not a
-     doc, so a single centered column reads more deliberate than a left rag
-     above a centered card. */
-  main { max-width: var(--max); margin: 0 auto; padding: 0 20px 60px; text-align: center; }
+  /* Headings and copy stay left, matching the rest of the site; only the
+     wall card centers its own contents. */
+  main { max-width: var(--max); margin: 0 auto; padding: 0 20px 60px; }
   section { margin-top: 72px; }
   h2 { font-size: clamp(24px, 3.6vw, 30px); line-height: 1.2; margin: 0 0 22px; letter-spacing: -0.01em; }
 
-  .hero { margin-top: 56px; max-width: 640px; margin-left: auto; margin-right: auto; }
+  .hero { margin-top: 56px; max-width: 640px; }
   h1 { font-size: clamp(32px, 5vw, 46px); line-height: 1.12; margin: 0 0 16px; letter-spacing: -0.02em; }
   .qd { color: var(--accent); }
   .lede { font-size: 17px; color: var(--ink-soft); margin: 0 0 26px; text-wrap: pretty; }
-  .actions { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+  .actions { display: flex; gap: 12px; flex-wrap: wrap; }
   .btn {
     display: inline-block; padding: 11px 22px; border-radius: 999px; font-weight: 600;
     border: 1.5px solid var(--ink); color: var(--ink); font-size: 15.5px;
@@ -62,7 +61,7 @@ import { SPONSOR_URL } from '../lib/sponsors.js'
 
   .fine-print {
     font-size: 13.5px; color: var(--ink-soft);
-    margin: 18px auto 0; max-width: 68ch; text-wrap: pretty;
+    margin: 18px 0 0; max-width: 72ch; text-wrap: pretty;
   }
 
   @media (max-width: 460px) {

--- a/apps/website/src/pages/sponsors.astro
+++ b/apps/website/src/pages/sponsors.astro
@@ -28,13 +28,6 @@ import { SPONSOR_URL } from '../lib/sponsors.js'
     <section class="wall-section">
       <h2>The wall</h2>
       <SponsorWall />
-      <p class="fine-print">
-        The wall syncs with <a href={SPONSOR_URL} rel="noopener">GitHub
-        Sponsors</a> daily — sponsor there and you appear here automatically,
-        name and avatar, no PR needed. Prefer a proper logo? Send an SVG via
-        <a href={`${GITHUB_URL}/issues`} rel="noopener">issue</a> and it
-        replaces the avatar.
-      </p>
     </section>
   </main>
 </Base>
@@ -58,11 +51,6 @@ import { SPONSOR_URL } from '../lib/sponsors.js'
   .btn:hover { text-decoration: none; background: var(--paper-2); }
   .btn.primary { background: var(--ink); color: var(--paper); }
   .btn.primary:hover { background: #000; }
-
-  .fine-print {
-    font-size: 13.5px; color: var(--ink-soft);
-    margin: 18px 0 0; max-width: 72ch; text-wrap: pretty;
-  }
 
   @media (max-width: 460px) {
     .actions { display: grid; grid-template-columns: 1fr; gap: 10px; }

--- a/apps/website/src/pages/sponsors.astro
+++ b/apps/website/src/pages/sponsors.astro
@@ -40,15 +40,18 @@ import { SPONSOR_URL } from '../lib/sponsors.js'
 </Base>
 
 <style>
-  main { max-width: var(--max); margin: 0 auto; padding: 0 20px 60px; }
+  /* The whole page centers on the wall's axis — it's a pitch page, not a
+     doc, so a single centered column reads more deliberate than a left rag
+     above a centered card. */
+  main { max-width: var(--max); margin: 0 auto; padding: 0 20px 60px; text-align: center; }
   section { margin-top: 72px; }
   h2 { font-size: clamp(24px, 3.6vw, 30px); line-height: 1.2; margin: 0 0 22px; letter-spacing: -0.01em; }
 
-  .hero { margin-top: 56px; max-width: 640px; }
+  .hero { margin-top: 56px; max-width: 640px; margin-left: auto; margin-right: auto; }
   h1 { font-size: clamp(32px, 5vw, 46px); line-height: 1.12; margin: 0 0 16px; letter-spacing: -0.02em; }
   .qd { color: var(--accent); }
   .lede { font-size: 17px; color: var(--ink-soft); margin: 0 0 26px; text-wrap: pretty; }
-  .actions { display: flex; gap: 12px; flex-wrap: wrap; }
+  .actions { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
   .btn {
     display: inline-block; padding: 11px 22px; border-radius: 999px; font-weight: 600;
     border: 1.5px solid var(--ink); color: var(--ink); font-size: 15.5px;
@@ -57,7 +60,10 @@ import { SPONSOR_URL } from '../lib/sponsors.js'
   .btn.primary { background: var(--ink); color: var(--paper); }
   .btn.primary:hover { background: #000; }
 
-  .fine-print { font-size: 13.5px; color: var(--ink-soft); margin-top: 18px; max-width: 72ch; }
+  .fine-print {
+    font-size: 13.5px; color: var(--ink-soft);
+    margin: 18px auto 0; max-width: 68ch; text-wrap: pretty;
+  }
 
   @media (max-width: 460px) {
     .actions { display: grid; grid-template-columns: 1fr; gap: 10px; }

--- a/apps/website/src/pages/sponsors.astro
+++ b/apps/website/src/pages/sponsors.astro
@@ -1,13 +1,10 @@
 ---
-// The sponsors page — a simple invite that points at GitHub Sponsors. No
-// tiers, no prices: the wall is one flat list that syncs from the GitHub
-// Sponsors API daily (see .github/workflows/sponsors.yml).
+// The sponsors page — a simple invite that points at GitHub Sponsors, and
+// the same wall component the homepage renders (uncapped here).
 import Base from '../layouts/Base.astro'
+import SponsorWall from '../components/SponsorWall.astro'
 import { GITHUB_URL } from '../consts.js'
-import { SPONSOR_URL, sponsors } from '../lib/sponsors.js'
-
-const all = sponsors()
-const empty = all.length === 0
+import { SPONSOR_URL } from '../lib/sponsors.js'
 ---
 <Base
   title="Sponsor Quickdraw — keep the whiteboard SDK MIT-licensed"
@@ -30,32 +27,7 @@ const empty = all.length === 0
 
     <section class="wall-section">
       <h2>The wall</h2>
-      {empty ? (
-        <div class="empty-wall">
-          <svg viewBox="0 0 24 24" width="30" height="30" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21s-7.5-4.6-9.5-9.2C1 8 3.2 4.6 6.8 4.6c2.2 0 3.9 1.2 5.2 3 1.3-1.8 3-3 5.2-3 3.6 0 5.8 3.4 4.3 7.2C19.5 16.4 12 21 12 21Z"/></svg>
-          <p class="empty-title">Nobody's here yet.</p>
-          <p>
-            Which means the first sponsors get the one thing money usually
-            can't buy on a sponsor wall: being first. Founding sponsors stay
-            marked as such for the life of the project.
-          </p>
-          <a class="btn primary" href={SPONSOR_URL} rel="noopener">Claim the first spot</a>
-        </div>
-      ) : (
-        <div class="row">
-          {all.map((s) => (
-            <a class="chip" href={s.url} rel="noopener sponsored" title={s.name}>
-              {s.logo
-                ? <img class="logo" src={s.logo} alt={s.name} loading="lazy" />
-                : <>{s.avatar && <img class="avatar" src={s.avatar} alt="" loading="lazy" />}<span class="chip-name">{s.name}</span></>}
-            </a>
-          ))}
-          <a class="chip your-slot" href={SPONSOR_URL} rel="noopener">
-            <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
-            Your logo
-          </a>
-        </div>
-      )}
+      <SponsorWall />
       <p class="fine-print">
         The wall syncs with <a href={SPONSOR_URL} rel="noopener">GitHub
         Sponsors</a> daily — sponsor there and you appear here automatically,
@@ -85,49 +57,10 @@ const empty = all.length === 0
   .btn.primary { background: var(--ink); color: var(--paper); }
   .btn.primary:hover { background: #000; }
 
-  .empty-wall {
-    text-align: center; background: #fff; border: 1.5px dashed var(--line);
-    border-radius: var(--radius); padding: 44px 26px;
-  }
-  .empty-wall svg { color: color-mix(in srgb, var(--accent) 70%, var(--ink)); margin-bottom: 8px; }
-  .empty-title { font-weight: 700; font-size: 18px; margin: 0 0 8px; color: var(--ink); }
-  .empty-wall p { color: var(--ink-soft); max-width: 46ch; margin: 0 auto 20px; text-wrap: pretty; }
-
-  .row { display: flex; flex-wrap: wrap; gap: 12px; }
-  .chip {
-    display: flex; align-items: center; justify-content: center; gap: 9px;
-    height: 60px; padding: 0 20px;
-    border: 1px solid var(--line); border-radius: 12px; background: #fff;
-    text-decoration: none;
-    transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
-  }
-  .chip:hover {
-    transform: translateY(-2px); text-decoration: none;
-    border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
-    box-shadow: 0 12px 26px -18px rgba(28, 27, 24, 0.5);
-  }
-  .chip .logo { max-height: 34px; max-width: 140px; object-fit: contain; display: block; }
-  .chip .avatar { width: 28px; height: 28px; border-radius: 50%; display: block; }
-  .chip-name { font-weight: 700; font-size: 14.5px; color: var(--ink); letter-spacing: -0.01em; }
-  .your-slot {
-    border: 1.5px dashed color-mix(in srgb, var(--accent) 45%, transparent);
-    color: color-mix(in srgb, var(--accent) 75%, var(--ink));
-    background: color-mix(in srgb, var(--accent) 4%, transparent);
-    font-weight: 600; font-size: 13.5px;
-  }
-  .your-slot:hover {
-    background: color-mix(in srgb, var(--accent) 9%, transparent);
-    border-color: color-mix(in srgb, var(--accent) 70%, transparent);
-  }
-
   .fine-print { font-size: 13.5px; color: var(--ink-soft); margin-top: 18px; max-width: 72ch; }
 
   @media (max-width: 460px) {
     .actions { display: grid; grid-template-columns: 1fr; gap: 10px; }
     .btn { text-align: center; }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .chip { transition: none; }
-    .chip:hover { transform: none; }
   }
 </style>

--- a/docs/star-history-dark.svg
+++ b/docs/star-history-dark.svg
@@ -9,7 +9,7 @@
   <rect x="0.5" y="0.5" width="799" height="309" rx="14" fill="#14130f" stroke="#2a2822"/>
   <g transform="translate(24 17) scale(0.75)"><path d="M12 1.6l3.1 6.7 7.3.9-5.4 5 1.4 7.2L12 17.8l-6.4 3.6L7 14.2 1.6 9.2l7.3-.9L12 1.6z" fill="#ffd154"/></g>
   <text x="47" y="33" fill="#f4f2ea" font-size="15" font-weight="700">20 stars</text>
-  <text x="776" y="33" fill="rgba(244, 242, 234, 0.5)" font-size="13" text-anchor="end">nmndwivedi/quickdraw</text>
+  <text x="776" y="33" fill="rgba(244, 242, 234, 0.5)" font-size="13" text-anchor="end">quickdrawjs/quickdraw</text>
   <line x1="56" x2="776" y1="266" y2="266" stroke="rgba(244, 242, 234, 0.13)" stroke-width="1" stroke-dasharray="3 6"/><line x1="56" x2="776" y1="165" y2="165" stroke="rgba(244, 242, 234, 0.13)" stroke-width="1" stroke-dasharray="3 6"/><line x1="56" x2="776" y1="64" y2="64" stroke="rgba(244, 242, 234, 0.13)" stroke-width="1" stroke-dasharray="3 6"/>
   <path d="M56 266 L111.5 255.9 L196.3 245.8 L202.9 235.7 L300.2 225.6 L302.2 215.5 L314.4 205.4 L394.8 195.3 L417.9 185.2 L451.7 175.1 L475.2 165 L543.8 154.9 L549.3 144.8 L587.2 134.7 L603.6 124.6 L634.8 114.5 L668.2 104.4 L708 94.3 L716 84.2 L723 74.1 L762 64 L776 64 L776 266 L56 266 Z" fill="url(#qd-star-fill)"/>
   <path d="M56 266 L111.5 255.9 L196.3 245.8 L202.9 235.7 L300.2 225.6 L302.2 215.5 L314.4 205.4 L394.8 195.3 L417.9 185.2 L451.7 175.1 L475.2 165 L543.8 154.9 L549.3 144.8 L587.2 134.7 L603.6 124.6 L634.8 114.5 L668.2 104.4 L708 94.3 L716 84.2 L723 74.1 L762 64 L776 64" fill="none" stroke="#ffd154" stroke-width="2.8" stroke-linejoin="round" stroke-linecap="round"/>

--- a/docs/star-history.json
+++ b/docs/star-history.json
@@ -1,5 +1,5 @@
 {
-  "repo": "nmndwivedi/quickdraw",
+  "repo": "quickdrawjs/quickdraw",
   "stars": 20,
   "createdAt": "2026-07-31T22:22:15Z",
   "generatedAt": "2026-08-02T12:23:29.848Z",

--- a/docs/star-history.svg
+++ b/docs/star-history.svg
@@ -9,7 +9,7 @@
   <rect x="0.5" y="0.5" width="799" height="309" rx="14" fill="#faf8f4" stroke="#e3dfd4"/>
   <g transform="translate(24 17) scale(0.75)"><path d="M12 1.6l3.1 6.7 7.3.9-5.4 5 1.4 7.2L12 17.8l-6.4 3.6L7 14.2 1.6 9.2l7.3-.9L12 1.6z" fill="#e0a106"/></g>
   <text x="47" y="33" fill="#1c1b18" font-size="15" font-weight="700">20 stars</text>
-  <text x="776" y="33" fill="#57544c" font-size="13" text-anchor="end">nmndwivedi/quickdraw</text>
+  <text x="776" y="33" fill="#57544c" font-size="13" text-anchor="end">quickdrawjs/quickdraw</text>
   <line x1="56" x2="776" y1="266" y2="266" stroke="#ded9cc" stroke-width="1" stroke-dasharray="3 6"/><line x1="56" x2="776" y1="165" y2="165" stroke="#ded9cc" stroke-width="1" stroke-dasharray="3 6"/><line x1="56" x2="776" y1="64" y2="64" stroke="#ded9cc" stroke-width="1" stroke-dasharray="3 6"/>
   <path d="M56 266 L111.5 255.9 L196.3 245.8 L202.9 235.7 L300.2 225.6 L302.2 215.5 L314.4 205.4 L394.8 195.3 L417.9 185.2 L451.7 175.1 L475.2 165 L543.8 154.9 L549.3 144.8 L587.2 134.7 L603.6 124.6 L634.8 114.5 L668.2 104.4 L708 94.3 L716 84.2 L723 74.1 L762 64 L776 64 L776 266 L56 266 Z" fill="url(#qd-star-fill)"/>
   <path d="M56 266 L111.5 255.9 L196.3 245.8 L202.9 235.7 L300.2 225.6 L302.2 215.5 L314.4 205.4 L394.8 195.3 L417.9 185.2 L451.7 175.1 L475.2 165 L543.8 154.9 L549.3 144.8 L587.2 134.7 L603.6 124.6 L634.8 114.5 L668.2 104.4 L708 94.3 L716 84.2 L723 74.1 L762 64 L776 64" fill="none" stroke="#e0a106" stroke-width="2.8" stroke-linejoin="round" stroke-linecap="round"/>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -107,7 +107,7 @@ Remote diffs don't enter local undo history, so collaborative undo stays sane.
 const blob = await editor.exportImage({ background: true, scale: 2 })
 ```
 
-See the [repository README](https://github.com/nmndwivedi/quickdraw) for the
+See the [repository README](https://github.com/quickdrawjs/quickdraw) for the
 full API, data model and guides.
 
 ## License

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,10 +38,10 @@
   "homepage": "https://tryquickdraw.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nmndwivedi/quickdraw.git",
+    "url": "https://github.com/quickdrawjs/quickdraw.git",
     "directory": "packages/core"
   },
-  "bugs": "https://github.com/nmndwivedi/quickdraw/issues",
+  "bugs": "https://github.com/quickdrawjs/quickdraw/issues",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/core/src/editor.js
+++ b/packages/core/src/editor.js
@@ -18,7 +18,7 @@ const RESIZE_CURSORS = {
   tl: 'nwse-resize', br: 'nwse-resize', tr: 'nesw-resize', bl: 'nesw-resize',
   t: 'ns-resize', b: 'ns-resize', l: 'ew-resize', r: 'ew-resize',
 }
-const DEFAULT_STYLES = { color: 'black', size: 'm', dash: 'draw', fill: 'none', font: 'draw' }
+const DEFAULT_STYLES = { color: 'blue', size: 'm', dash: 'draw', fill: 'none', font: 'draw' }
 
 export const TOOLS = ['select', 'hand', 'draw', 'highlight', 'eraser', 'laser', 'arrow', 'line', 'geo', 'text', 'note']
 
@@ -260,10 +260,40 @@ export class Editor {
   setTheme(id) {
     const t = themeOf(id)
     if (t === this.theme) return
+    this._crossfadeTheme()
     this.theme = t
     this.container.dataset.qdTheme = t.id
     this.requestRender()
     this.emit('theme')
+  }
+  // Freeze the outgoing theme as a bitmap over the board and fade it out, so
+  // a theme switch melts from one paper to the other instead of hard-cutting.
+  _crossfadeTheme() {
+    if (this._destroyed) return
+    if (typeof window !== 'undefined' &&
+        window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return
+    const w = this.canvas.width, h = this.canvas.height
+    if (!w || !h) return
+    try {
+      const snap = document.createElement('canvas')
+      snap.width = w
+      snap.height = h
+      snap.getContext('2d').drawImage(this.canvas, 0, 0)
+      snap.className = 'qd-theme-fade'
+      this._themeFade?.remove()
+      this._themeFade = snap
+      this.overlay.after(snap)
+      // two frames: one to paint at full opacity, one to start the transition
+      requestAnimationFrame(() => requestAnimationFrame(() => { snap.style.opacity = '0' }))
+      const done = () => {
+        snap.remove()
+        if (this._themeFade === snap) this._themeFade = null
+      }
+      snap.addEventListener('transitionend', done, { once: true })
+      setTimeout(done, 600) // safety net if transitionend never fires
+    } catch {
+      // a stubbed 2D context (tests, exotic embeds) just skips the fade
+    }
   }
   // 'none' | 'lines' | 'dots' — the backdrop behind the drawing
   setGrid(id) {
@@ -871,7 +901,7 @@ export class Editor {
     this.store.put({
       id, typeName: 'shape', type: 'note', x: p.x - NOTE_W / 2, y: p.y - NOTE_W / 2, rot: 0,
       z: this.store.maxZ() + 1,
-      props: { text: '', color: this.styles.color === 'black' ? 'yellow' : this.styles.color, size: 'm', font: this.styles.font, scale: 1 },
+      props: { text: '', color: this.styles.color === DEFAULT_STYLES.color ? 'yellow' : this.styles.color, size: 'm', font: this.styles.font, scale: 1 },
     })
     this.setTool('select')
     this.setSelection([id])
@@ -1818,6 +1848,8 @@ export class Editor {
   destroy() {
     this._destroyed = true
     this._commitText()
+    this._themeFade?.remove()
+    this._themeFade = null
     cancelAnimationFrame(this._raf)
     cancelAnimationFrame(this._camAnim)
     cancelAnimationFrame(this._fitEaseRaf || 0)

--- a/packages/core/src/quickdraw.css
+++ b/packages/core/src/quickdraw.css
@@ -14,6 +14,19 @@
   container-type: inline-size;
 }
 .qd-root[data-qd-theme='dark'] { background: #191713; }
+.qd-root { transition: background 320ms ease; }
+
+/* snapshot of the outgoing theme, faded out by the editor on setTheme() */
+.qd-theme-fade {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 20; /* over canvas + overlay, under the floating chrome */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 320ms ease;
+}
 
 .qd-canvas, .qd-overlay {
   position: absolute;

--- a/packages/core/src/quickdraw.css
+++ b/packages/core/src/quickdraw.css
@@ -1,5 +1,8 @@
 /* Quickdraw styles — self-contained, no preprocessor, importable raw.
-   The dock is dark glass so it reads on either theme's paper. */
+   All floating chrome (dock, actions, popovers) follows the board's theme
+   through the --qd-* custom properties below: dark glass on the dark paper,
+   light glass on the light one. Theme switches animate because the surfaces
+   transition background/color/border while the variables flip. */
 
 .qd-root {
   position: relative;
@@ -10,11 +13,53 @@
   background: #fbf9f4;
   touch-action: none;
   border-radius: inherit;
+  transition: background 320ms ease;
   /* lets the watermark dodge the dock on narrow boards (see below) */
   container-type: inline-size;
+
+  /* light-theme chrome */
+  --qd-bar-bg: rgba(255, 255, 255, 0.88);
+  --qd-pop-bg: rgba(255, 255, 255, 0.94);
+  --qd-border: rgba(28, 27, 24, 0.12);
+  --qd-bar-shadow: 0 4px 16px rgba(28, 27, 24, 0.14);
+  --qd-pop-shadow: 0 8px 28px rgba(28, 27, 24, 0.2);
+  --qd-ink: rgba(28, 27, 24, 0.82);
+  --qd-ink-strong: rgba(28, 27, 24, 0.94);
+  --qd-ink-soft: rgba(28, 27, 24, 0.55);
+  --qd-ink-faint: rgba(28, 27, 24, 0.4);
+  --qd-hover: rgba(28, 27, 24, 0.07);
+  --qd-hover-strong: rgba(28, 27, 24, 0.1);
+  --qd-active: rgba(28, 27, 24, 0.12);
+  --qd-on-bg: #211d14;
+  --qd-on-ink: #fbf9f4;
+  --qd-divider: rgba(28, 27, 24, 0.14);
+  --qd-menu-div: rgba(28, 27, 24, 0.1);
+  --qd-seg-bg: rgba(28, 27, 24, 0.07);
+  --qd-dot-ring: rgba(28, 27, 24, 0.12);
 }
-.qd-root[data-qd-theme='dark'] { background: #191713; }
-.qd-root { transition: background 320ms ease; }
+.qd-root[data-qd-theme='dark'] {
+  background: #191713;
+
+  /* dark-theme chrome: the original dark glass */
+  --qd-bar-bg: rgba(19, 17, 13, 0.72);
+  --qd-pop-bg: rgba(19, 17, 13, 0.85);
+  --qd-border: rgba(255, 255, 255, 0.14);
+  --qd-bar-shadow: 0 4px 16px rgba(10, 8, 4, 0.25);
+  --qd-pop-shadow: 0 8px 28px rgba(10, 8, 4, 0.35);
+  --qd-ink: rgba(255, 255, 255, 0.85);
+  --qd-ink-strong: rgba(255, 255, 255, 0.95);
+  --qd-ink-soft: rgba(255, 255, 255, 0.62);
+  --qd-ink-faint: rgba(255, 255, 255, 0.4);
+  --qd-hover: rgba(255, 255, 255, 0.1);
+  --qd-hover-strong: rgba(255, 255, 255, 0.12);
+  --qd-active: rgba(255, 255, 255, 0.22);
+  --qd-on-bg: rgba(255, 255, 255, 0.92);
+  --qd-on-ink: #211d14;
+  --qd-divider: rgba(255, 255, 255, 0.16);
+  --qd-menu-div: rgba(255, 255, 255, 0.1);
+  --qd-seg-bg: rgba(255, 255, 255, 0.08);
+  --qd-dot-ring: rgba(255, 255, 255, 0.12);
+}
 
 /* snapshot of the outgoing theme, faded out by the editor on setTheme() */
 .qd-theme-fade {
@@ -37,6 +82,8 @@
 .qd-overlay { pointer-events: none; }
 
 /* ---- floating chrome ---- */
+/* The theme switch rides these transitions; hovers use the same clock, which
+   at 140–320ms still reads as instant. */
 .qd-ui { position: absolute; inset: 0; pointer-events: none; z-index: 40; }
 .qd-ui.qd-hidden { display: none; }
 .qd-ui button { -webkit-tap-highlight-color: transparent; }
@@ -52,12 +99,13 @@
   gap: 2px;
   padding: 5px 7px;
   border-radius: 999px;
-  background: rgba(19, 17, 13, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  box-shadow: 0 4px 16px rgba(10, 8, 4, 0.25);
+  background: var(--qd-bar-bg);
+  border: 1px solid var(--qd-border);
+  box-shadow: var(--qd-bar-shadow);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   pointer-events: auto;
+  transition: background 320ms ease, border-color 320ms ease, box-shadow 320ms ease;
 }
 
 /* history + selection actions: a vertical pill hugging the left edge.
@@ -73,16 +121,17 @@
   gap: 2px;
   padding: 6px 4px;
   border-radius: 999px;
-  background: rgba(19, 17, 13, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  box-shadow: 0 4px 16px rgba(10, 8, 4, 0.25);
+  background: var(--qd-bar-bg);
+  border: 1px solid var(--qd-border);
+  box-shadow: var(--qd-bar-shadow);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   pointer-events: auto;
+  transition: background 320ms ease, border-color 320ms ease, box-shadow 320ms ease;
 }
 .qd-actions button svg { width: 17px; height: 17px; display: block; }
 .qd-actions .qd-div { width: 18px; height: 1px; margin: 3px 0; }
-.qd-actions button:hover { background: rgba(255, 255, 255, 0.1); }
+.qd-actions button:hover { background: var(--qd-hover); }
 .qd-actions button:disabled { opacity: 0.32; pointer-events: none; }
 .qd-actions .qd-tool { width: 30px; height: 30px; }
 
@@ -96,15 +145,16 @@
   border: none;
   border-radius: 9px;
   background: transparent;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--qd-ink);
   cursor: pointer;
   padding: 0;
+  transition: background 140ms ease, color 140ms ease;
 }
 .qd-dock button svg { width: 19px; height: 19px; display: block; }
-.qd-dock button:hover { background: rgba(255, 255, 255, 0.1); }
-.qd-dock button.on { background: rgba(255, 255, 255, 0.92); color: #211d14; }
+.qd-dock button:hover { background: var(--qd-hover); }
+.qd-dock button.on { background: var(--qd-on-bg); color: var(--qd-on-ink); }
 .qd-dock button:disabled { opacity: 0.32; pointer-events: none; }
-.qd-div { width: 1px; height: 20px; margin: 0 3px; background: rgba(255, 255, 255, 0.16); flex: none; }
+.qd-div { width: 1px; height: 20px; margin: 0 3px; background: var(--qd-divider); flex: none; transition: background 320ms ease; }
 .qd-dock.qd-compact { gap: 2px; }
 
 .qd-geo-btn { position: relative; }
@@ -125,10 +175,11 @@
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  border: 2.5px solid rgba(255, 255, 255, 0.92);
+  border: 2.5px solid var(--qd-on-bg);
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+  transition: border-color 320ms ease;
 }
-.qd-style-btn.on .qd-style-dot { border-color: #211d14; }
+.qd-style-btn.on .qd-style-dot { border-color: var(--qd-on-ink); }
 
 /* ---- popovers ---- */
 .qd-popover {
@@ -136,15 +187,16 @@
   bottom: 54px;
   left: 50%;
   border-radius: 13px;
-  background: rgba(19, 17, 13, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  box-shadow: 0 8px 28px rgba(10, 8, 4, 0.35);
+  background: var(--qd-pop-bg);
+  border: 1px solid var(--qd-border);
+  box-shadow: var(--qd-pop-shadow);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   pointer-events: auto;
   padding: 8px;
   max-width: calc(100% - 16px);
   box-sizing: border-box;
+  transition: background 320ms ease, border-color 320ms ease, box-shadow 320ms ease;
   /* rise out of the dock: a short fade + lift + settle */
   transform-origin: 50% 100%;
   animation: qd-pop-in 160ms cubic-bezier(0.2, 0.9, 0.3, 1.15);
@@ -162,16 +214,16 @@
 .qd-popover .qd-tool svg { width: 19px; height: 19px; display: block; }
 
 .qd-geo-pop { display: flex; gap: 2px; flex-wrap: wrap; }
-.qd-geo-pop .qd-tool { color: rgba(255, 255, 255, 0.85); }
+.qd-geo-pop .qd-tool { color: var(--qd-ink); }
 
 /* overflow tools ("more" flyout / folded kit) */
 .qd-grid-pop { display: grid; grid-template-columns: repeat(4, 32px); gap: 2px; }
-.qd-grid-pop .qd-tool { color: rgba(255, 255, 255, 0.85); }
-.qd-grid-pop .qd-tool.on { background: rgba(255, 255, 255, 0.92); color: #211d14; }
+.qd-grid-pop .qd-tool { color: var(--qd-ink); }
+.qd-grid-pop .qd-tool.on { background: var(--qd-on-bg); color: var(--qd-on-ink); }
 
 .qd-style-pop { width: 196px; }
 .qd-row { display: flex; align-items: center; justify-content: space-between; }
-.qd-row + .qd-row { margin-top: 7px; padding-top: 7px; border-top: 1px solid rgba(255, 255, 255, 0.1); }
+.qd-row + .qd-row { margin-top: 7px; padding-top: 7px; border-top: 1px solid var(--qd-menu-div); }
 .qd-colors { display: grid; grid-template-columns: repeat(6, 1fr); gap: 3px; }
 .qd-dot {
   width: 26px;
@@ -184,6 +236,7 @@
   justify-content: center;
   cursor: pointer;
   padding: 0;
+  transition: background 140ms ease;
 }
 .qd-dot::before {
   content: '';
@@ -191,10 +244,10 @@
   height: 15px;
   border-radius: 50%;
   background: var(--dot);
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12);
+  box-shadow: 0 0 0 1px var(--qd-dot-ring);
 }
-.qd-dot:hover { background: rgba(255, 255, 255, 0.1); }
-.qd-dot.on { background: rgba(255, 255, 255, 0.22); }
+.qd-dot:hover { background: var(--qd-hover); }
+.qd-dot.on { background: var(--qd-active); }
 
 .qd-opt {
   width: 40px;
@@ -202,16 +255,17 @@
   border: none;
   border-radius: 8px;
   background: transparent;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--qd-ink);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   padding: 0;
+  transition: background 140ms ease, color 140ms ease;
 }
 .qd-opt svg { width: 20px; height: 20px; }
-.qd-opt:hover { background: rgba(255, 255, 255, 0.1); }
-.qd-opt.on { background: rgba(255, 255, 255, 0.92); color: #211d14; }
+.qd-opt:hover { background: var(--qd-hover); }
+.qd-opt.on { background: var(--qd-on-bg); color: var(--qd-on-ink); }
 .qd-size-pip {
   width: var(--pip);
   height: var(--pip);
@@ -226,26 +280,27 @@
   gap: 10px;
   border: none;
   background: transparent;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--qd-ink-strong);
   text-align: left;
   font: 500 12.5px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   padding: 7px 10px;
   border-radius: 8px;
   cursor: pointer;
+  transition: background 140ms ease, color 140ms ease;
 }
-.qd-menu-item:hover { background: rgba(255, 255, 255, 0.1); }
-.qd-mi-ico { display: flex; flex: 0 0 16px; color: rgba(255, 255, 255, 0.62); }
+.qd-menu-item:hover { background: var(--qd-hover); }
+.qd-mi-ico { display: flex; flex: 0 0 16px; color: var(--qd-ink-soft); }
 .qd-mi-ico svg { width: 16px; height: 16px; }
 .qd-menu-item:hover .qd-mi-ico { color: inherit; }
 .qd-mi-label { flex: 1 1 auto; white-space: nowrap; }
 .qd-mi-key {
   flex: 0 0 auto;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--qd-ink-faint);
   font-size: 11px;
   letter-spacing: 0.02em;
   font-variant-numeric: tabular-nums;
 }
-.qd-menu-div { display: block; height: 1px; margin: 5px 4px; background: rgba(255, 255, 255, 0.1); }
+.qd-menu-div { display: block; height: 1px; margin: 5px 4px; background: var(--qd-menu-div); }
 
 /* labelled rows of mutually exclusive icon buttons (grid, theme) */
 .qd-menu-row {
@@ -253,7 +308,7 @@
   align-items: center;
   gap: 10px;
   padding: 4px 10px 4px 10px;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--qd-ink-strong);
   font: 500 12.5px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 .qd-menu-row + .qd-menu-row { margin-top: 2px; }
@@ -262,7 +317,8 @@
   gap: 2px;
   padding: 2px;
   border-radius: 9px;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--qd-seg-bg);
+  transition: background 320ms ease;
 }
 .qd-seg-btn {
   width: 30px;
@@ -270,7 +326,7 @@
   border: none;
   border-radius: 7px;
   background: transparent;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--qd-ink);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -279,16 +335,16 @@
   transition: background 120ms ease, color 120ms ease;
 }
 .qd-seg-btn svg { width: 16px; height: 16px; }
-.qd-seg-btn:hover { background: rgba(255, 255, 255, 0.12); color: #fff; }
-.qd-seg-btn.on { background: rgba(255, 255, 255, 0.92); color: #211d14; }
+.qd-seg-btn:hover { background: var(--qd-hover-strong); color: var(--qd-ink-strong); }
+.qd-seg-btn.on { background: var(--qd-on-bg); color: var(--qd-on-ink); }
 
 /* nested dropdown (grid backdrop): a flyout beside the parent row */
-.qd-mi-value { flex: 0 0 auto; color: rgba(255, 255, 255, 0.45); font-size: 11.5px; }
-.qd-mi-chev, .qd-mi-check { flex: 0 0 14px; display: flex; color: rgba(255, 255, 255, 0.4); }
+.qd-mi-value { flex: 0 0 auto; color: var(--qd-ink-faint); font-size: 11.5px; }
+.qd-mi-chev, .qd-mi-check { flex: 0 0 14px; display: flex; color: var(--qd-ink-faint); }
 .qd-mi-chev svg, .qd-mi-check svg { width: 14px; height: 14px; }
-.qd-mi-check { color: rgba(255, 255, 255, 0.85); }
+.qd-mi-check { color: var(--qd-ink); }
 .qd-has-sub { position: relative; }
-.qd-has-sub.sub-open { background: rgba(255, 255, 255, 0.1); }
+.qd-has-sub.sub-open { background: var(--qd-hover); }
 .qd-submenu {
   position: absolute;
   left: calc(100% + 2px);
@@ -298,9 +354,9 @@
   min-width: 148px;
   padding: 6px;
   border-radius: 13px;
-  background: rgba(19, 17, 13, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  box-shadow: 0 8px 28px rgba(10, 8, 4, 0.35);
+  background: var(--qd-pop-bg);
+  border: 1px solid var(--qd-border);
+  box-shadow: var(--qd-pop-shadow);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   animation: qd-sub-in 130ms ease;
@@ -338,7 +394,7 @@
   letter-spacing: 0.01em;
   text-decoration: none;
   -webkit-tap-highlight-color: transparent;
-  transition: color 140ms ease, background 140ms ease;
+  transition: color 320ms ease, background 140ms ease;
 }
 .qd-watermark svg { width: 14px; height: 14px; display: block; }
 .qd-watermark:hover {

--- a/packages/core/src/ui.js
+++ b/packages/core/src/ui.js
@@ -481,7 +481,7 @@ export function buildUI(editor, { hidden = false, onSave, themeToggle = true, gr
     // the folded button wears the active tool so the state stays visible
     toolsBtn.innerHTML = ICONS[editor.tool === 'geo' ? editor.geoKind : editor.tool] || ICONS.select
     toolsBtn.classList.toggle('on', popover?.name === 'tools')
-    styleDot.style.background = editor.theme.colors[editor.currentStyles().color || 'black'].stroke
+    styleDot.style.background = editor.theme.colors[editor.currentStyles().color || 'blue'].stroke
     menuBtn.classList.toggle('on', popover?.name === 'menu')
     styleBtn.classList.toggle('on', popover?.name === 'styles')
     moreBtn.classList.toggle('on', popover?.name === 'more')

--- a/packages/core/test/editor.test.js
+++ b/packages/core/test/editor.test.js
@@ -255,7 +255,7 @@ describe('text & notes', () => {
     expect(editor.store.shapes().length).toBe(1)
   })
 
-  it('notes get the note default color when pen is black', () => {
+  it('notes get the note default color when the pen is on the default ink', () => {
     editor.setTool('note')
     drag(editor, [[50, 50]])
     const note = editor.store.shapes().find((s) => s.type === 'note')

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -75,7 +75,7 @@ changes stay out of local undo history.
 // socket.onmessage: board.current.applyDiff(JSON.parse(data))
 ```
 
-See the [repository README](https://github.com/nmndwivedi/quickdraw) for the
+See the [repository README](https://github.com/quickdrawjs/quickdraw) for the
 full API.
 
 ## License

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -52,10 +52,10 @@
   "homepage": "https://tryquickdraw.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nmndwivedi/quickdraw.git",
+    "url": "https://github.com/quickdrawjs/quickdraw.git",
     "directory": "packages/react-native"
   },
-  "bugs": "https://github.com/nmndwivedi/quickdraw/issues",
+  "bugs": "https://github.com/quickdrawjs/quickdraw/issues",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -93,7 +93,7 @@ useEffect(() => {
 <Quickdraw store={store} />
 ```
 
-See the [repository README](https://github.com/nmndwivedi/quickdraw) for the
+See the [repository README](https://github.com/quickdrawjs/quickdraw) for the
 full API.
 
 ## License

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -39,10 +39,10 @@
   "homepage": "https://tryquickdraw.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nmndwivedi/quickdraw.git",
+    "url": "https://github.com/quickdrawjs/quickdraw.git",
     "directory": "packages/react"
   },
-  "bugs": "https://github.com/nmndwivedi/quickdraw/issues",
+  "bugs": "https://github.com/quickdrawjs/quickdraw/issues",
   "publishConfig": {
     "access": "public"
   }

--- a/scripts/sponsors.mjs
+++ b/scripts/sponsors.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Refreshes docs/sponsors.json from the GitHub Sponsors GraphQL API, so the
+// website's sponsor wall updates itself — nobody edits a list by hand when a
+// sponsorship starts or lapses. Same shape as star-history: CI runs this on a
+// schedule and commits the snapshot; the static build just reads the file.
+//
+// Reading sponsorships needs an authenticated token. The Actions token can
+// usually read an org's public sponsors; if GitHub rejects it, add a classic
+// PAT with read:org as the SPONSORS_TOKEN repo secret (the workflow prefers
+// it when present).
+//
+//   GITHUB_TOKEN=<token> node scripts/sponsors.mjs
+
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const LOGIN = process.env.SPONSORS_LOGIN ?? 'quickdrawjs'
+const OUT = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs')
+
+const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN
+if (!token) {
+  console.error('sponsors: GITHUB_TOKEN is required — the Sponsors API rejects anonymous reads.')
+  process.exit(1)
+}
+
+const SPONSOR_FIELDS = `
+  totalCount
+  nodes {
+    createdAt
+    isOneTimePayment
+    tier { monthlyPriceInDollars }
+    sponsorEntity {
+      ... on User { login name avatarUrl url websiteUrl }
+      ... on Organization { login name avatarUrl url websiteUrl }
+    }
+  }
+`
+
+// The profile might live on an org or a user account — ask for both and take
+// whichever exists. includePrivate stays false: private sponsors asked not to
+// be shown, and this file is public.
+const QUERY = `
+  query($login: String!) {
+    organization(login: $login) {
+      sponsorshipsAsMaintainer(first: 100, activeOnly: true, includePrivate: false, orderBy: { field: CREATED_AT, direction: ASC }) { ${SPONSOR_FIELDS} }
+    }
+    user(login: $login) {
+      sponsorshipsAsMaintainer(first: 100, activeOnly: true, includePrivate: false, orderBy: { field: CREATED_AT, direction: ASC }) { ${SPONSOR_FIELDS} }
+    }
+  }
+`
+
+const res = await fetch('https://api.github.com/graphql', {
+  method: 'POST',
+  headers: {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    'User-Agent': 'quickdraw-sponsors',
+  },
+  body: JSON.stringify({ query: QUERY, variables: { login: LOGIN } }),
+})
+if (!res.ok) {
+  console.error(`sponsors: GraphQL request failed — ${res.status} ${res.statusText}`)
+  process.exit(1)
+}
+const payload = await res.json()
+
+// "Could not resolve to an Organization" for the unused half is expected —
+// only bail when neither half resolved.
+const conn =
+  payload.data?.organization?.sponsorshipsAsMaintainer ??
+  payload.data?.user?.sponsorshipsAsMaintainer
+if (!conn) {
+  console.error('sponsors: no sponsorable account found for', LOGIN, JSON.stringify(payload.errors ?? payload))
+  process.exit(1)
+}
+
+const sponsors = (conn.nodes ?? [])
+  .filter((n) => n?.sponsorEntity?.login)
+  .map((n) => ({
+    login: n.sponsorEntity.login,
+    name: n.sponsorEntity.name || n.sponsorEntity.login,
+    url: n.sponsorEntity.websiteUrl || n.sponsorEntity.url,
+    avatar: n.sponsorEntity.avatarUrl,
+    monthly: n.tier?.monthlyPriceInDollars ?? 0,
+    oneTime: !!n.isOneTimePayment,
+    since: n.createdAt?.slice(0, 10) ?? null,
+  }))
+
+mkdirSync(OUT, { recursive: true })
+writeFileSync(
+  join(OUT, 'sponsors.json'),
+  JSON.stringify({ generatedAt: new Date().toISOString(), login: LOGIN, sponsors }, null, 2) + '\n',
+)
+console.log(`sponsors: wrote ${sponsors.length} sponsor(s) to docs/sponsors.json`)

--- a/scripts/star-history.mjs
+++ b/scripts/star-history.mjs
@@ -19,7 +19,7 @@ import { dirname, join } from 'node:path'
 import { buildStarChart } from '../apps/website/src/lib/starChart.js'
 import { renderStarSvg, THEMES, VIEW } from './lib/starSvg.mjs'
 
-const REPO = process.env.STAR_HISTORY_REPO ?? 'nmndwivedi/quickdraw'
+const REPO = process.env.STAR_HISTORY_REPO ?? 'quickdrawjs/quickdraw'
 const API = `https://api.github.com/repos/${REPO}`
 const OUT = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs')
 const PER_PAGE = 100


### PR DESCRIPTION
## What's in here

**1. Default ink is blue.** `DEFAULT_STYLES.color` is now `blue` in the core editor. Sticky notes keep their yellow paper when the pen is on the default ink.

**2. All canvas chrome follows the theme.** The dock, actions pill, popovers, and the app's logo / file bar / files menu were dark glass in both themes. They now render light glass with dark ink on light paper, and the original dark glass on dark — driven by `--qd-*` custom properties in `quickdraw.css` plus matching vars in the app's `index.html`.

**3. Theme switching is smooth.** `setTheme()` freezes the outgoing canvas as a bitmap and fades it out over 320ms (skipped under `prefers-reduced-motion`, cleaned up on `destroy()`), and every chrome surface transitions on the same clock, so the whole switch reads as one motion instead of a hard cut.

**4. Sponsors.** A self-updating sponsor wall:
- `.github/workflows/sponsors.yml` pulls active public sponsors from the GitHub Sponsors GraphQL API daily into `docs/sponsors.json`; the site reads that snapshot at build time
- One shared `SponsorWall.astro` renders the homepage teaser (top 8, then "+N more →") and the full `/sponsors` page
- No tiers, no prices — a flat row of avatar chips, with a designed empty state whose ghost slots fade out symmetrically from a live "Your logo here" invite
- Every CTA links straight to GitHub Sponsors checkout
- `.github/FUNDING.yml` lights up the repo's Sponsor button

**5. Made with Quickdraw.** README showcase table plus a CONTRIBUTING section documenting the add-a-row-and-open-a-PR flow.

**6. Org rename.** Every GitHub and Sponsors URL across the repo now points at `quickdrawjs/quickdraw` and `sponsors/quickdrawjs`.

## Verified
- 125 tests pass, typecheck clean, website builds (18 pages incl. `/sponsors`), React Native bundle regenerated
- Browser-checked: blue ink, chrome following the theme in both modes, the crossfade element appearing during a switch and removing itself after, and the sponsor wall in both empty and populated states

## Note
The wall ships empty and fills itself once the GitHub Sponsors profile is approved. If the first workflow run can't read sponsorships with the default Actions token, add a classic PAT with `read:org` as a repo secret named `SPONSORS_TOKEN` — the workflow prefers it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)